### PR TITLE
Change Validate to run all checks for type

### DIFF
--- a/src/NServiceBus.Testing.Tests/InvocationTests.cs
+++ b/src/NServiceBus.Testing.Tests/InvocationTests.cs
@@ -171,6 +171,20 @@
 
             exp.Validate(i);
         }
+
+        [Test]
+        public void RunAllInvocations()
+        {
+            int invocationCount = 0;
+
+            var i = new PublishInvocation<MessageA> { Message = new MessageA() };
+            var j = new PublishInvocation<MessageA> { Message = new MessageA() };
+            var exp = new ExpectedPublishInvocation<MessageA> { Check = m => { invocationCount++;  return true; } };
+
+            exp.Validate(i, j);
+
+            Assert.That(() => invocationCount, Is.EqualTo(2));
+        }
     }
 
     public class MessageA

--- a/src/NServiceBus.Testing/Invocations.cs
+++ b/src/NServiceBus.Testing/Invocations.cs
@@ -16,12 +16,14 @@
         public void Validate(params ActualInvocation[] invocations)
         {
             var calls = invocations.Where(i => typeof(T) == i.GetType());
-            var success = calls.Any(c =>
-                                         {
-                                             var result = Validate(c as T);
-                                             
-                                             return result;
-                                         });
+
+            var callResults = calls.Select(c =>
+            {
+                var result = Validate(c as T);
+                return result;
+            }).ToArray(); // Force enumeration
+
+            var success = callResults.Any(result => result);
 
             if ((!success && !Negate) || (Negate && success))
                 throw new Exception(string.Format("{0} not fulfilled.\nCalls made:\n{1}", filter(GetType()), string.Join("\n", invocations.Select(i => filter(i.GetType())))));


### PR DESCRIPTION
The Validate method currently exits on the first instance of
Func<T, bool> that returns true. This makes it difficult for users to
test that a particular message is sent multiple times in response to
a single Handle.

This change enumerates over all matching invocations, before returning
true if any of the invocations was successful.

This relates to https://github.com/Particular/NServiceBus.Testing/issues/30