### PR TITLE
Change Validate to run all checks for type

### DIFF
--- a/src/NServiceBus.Testing.Tests/InvocationTests.cs
+++ b/src/NServiceBus.Testing.Tests/InvocationTests.cs
@@ -171,6 +171,20 @@
 
             exp.Validate(i);
         }
+
+        [Test]
+        public void RunAllInvocations()
+        {
+            var invocationCount = 0;
+
+            var i = new PublishInvocation<MessageA> { Message = new MessageA() };
+            var j = new PublishInvocation<MessageA> { Message = new MessageA() };
+            var exp = new ExpectedPublishInvocation<MessageA> { Check = m => { invocationCount++;  return true; } };
+
+            exp.Validate(i, j);
+
+            Assert.That(() => invocationCount, Is.EqualTo(2));
+        }
     }
 
     public class MessageA

--- a/src/NServiceBus.Testing/Invocations.cs
+++ b/src/NServiceBus.Testing/Invocations.cs
@@ -15,13 +15,10 @@
     {
         public void Validate(params ActualInvocation[] invocations)
         {
-            var calls = invocations.Where(i => typeof(T) == i.GetType());
-            var success = calls.Any(c =>
-                                         {
-                                             var result = Validate(c as T);
-                                             
-                                             return result;
-                                         });
+            var calls = invocations.Where(i => typeof(T) == i.GetType()).Cast<T>();
+            var callResults = calls.Select(c => Validate(c)).ToArray(); // Force enumeration
+
+            var success = callResults.Any(result => result);
 
             if ((!success && !Negate) || (Negate && success))
                 throw new Exception(string.Format("{0} not fulfilled.\nCalls made:\n{1}", filter(GetType()), string.Join("\n", invocations.Select(i => filter(i.GetType())))));


### PR DESCRIPTION
Anybody using NServiceBus.Testing

ExpectSend only executes until the first check passes for the specified
type.

The Validate method currently exits on the first instance of check that
returns true. This makes it impossible for users to test that a
particular message is sent multiple times in response to a single
handle.