### PR TITLE
[WIP] Assert saga state

### DIFF
--- a/src/NServiceBus.Testing.Tests/SagaTests.cs
+++ b/src/NServiceBus.Testing.Tests/SagaTests.cs
@@ -170,6 +170,17 @@
                 .ExpectNotForwardCurrentMessageTo(dest => dest == "expectedDestination")
                 .When(s => s.Handle(new StartsSaga()));
         }
+
+        [Test]
+        public void ShouldPassAssertSagaData()
+        {
+            var orderId = Guid.NewGuid();
+            var customerId = Guid.NewGuid();
+            Test.Saga<DiscountPolicy>()
+                .AssertSagaData<DiscountPolicyData>(state => state.RunningTotal == 0M)
+                .When(s => s.Handle(new SubmitOrder {CustomerId = customerId, OrderId = orderId, Total = 123.99M}))
+                .AssertSagaData<DiscountPolicyData>(state => state.CustomerId == customerId && state.RunningTotal == 123.99M);
+        }
     }
 
 

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -354,6 +354,18 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Assert that the saga data contains satisfies the predicate
+        /// </summary>
+        public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData
+        {
+            if (check((TSagaData)saga.Entity))
+            {
+                return this;
+            }
+            throw new Exception("Assert failed. Saga data did not contain the expected values.");
+        }
+
+        /// <summary>
         /// Verifies that the saga is setting the specified timeout
         /// </summary>
         public Saga<T> ExpectTimeoutToBeSetIn<TMessage>(Func<TMessage, TimeSpan, bool> check = null)

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -356,7 +356,7 @@ namespace NServiceBus.Testing
         /// <summary>
         /// Assert that the saga data contains satisfies the predicate
         /// </summary>
-        public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData
+        public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData, new()
         {
             if (!(saga.Entity is TSagaData))
             {

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -358,6 +358,10 @@ namespace NServiceBus.Testing
         /// </summary>
         public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData
         {
+            if (!(saga.Entity is TSagaData))
+            {
+                throw new Exception($"Assert failed. Saga data type provided `{typeof(TSagaData)}` is not matching the actual saga type `{saga.Entity.GetType()}`");
+            }
             if (check((TSagaData)saga.Entity))
             {
                 return this;


### PR DESCRIPTION
Allow saga state assertion as part of the fluent API.
Currently it's possible, but requires some ["creativity"](https://github.com/SeanFeldman/NSB.Testing.SagaState.and.Interface.based.Messages/blob/76d74d0630883d58daa3fe71f6341ea6130a603d/TestingWithInterfaces/When_testing_saga_for_state.cs#L51) and doesn't feel like a first class citizen.

Limitation: requires to pass the saga data type for predicate to work. Looks like this is due to the limitation of the test project `Saga` that is inheriting from `NSB.Saga`, rather than `NSB.Saga<T>`.

@DavidBoike let's pair up and see if this is worth trying and if can be improved 