### PR TITLE
[SPIKE] [WIP] Assert saga state fluent api

### DIFF
--- a/src/NServiceBus.Testing.Tests/SagaTests.cs
+++ b/src/NServiceBus.Testing.Tests/SagaTests.cs
@@ -54,10 +54,10 @@
             Test.Saga<DiscountPolicy>()
                 .ExpectSend<ProcessOrder>(m => m.Total == total)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = total}))
-                .ExpectSend<ProcessOrder>(m => m.Total == total*(decimal) 0.9)
+                .When(s => s.Handle(new SubmitOrder { Total = total }))
+                .ExpectSend<ProcessOrder>(m => m.Total == total * (decimal)0.9)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = total}));
+                .When(s => s.Handle(new SubmitOrder { Total = total }));
         }
 
         [Test]
@@ -78,11 +78,11 @@
             Test.Saga<DiscountPolicy>()
                 .ExpectSend<ProcessOrder>(m => m.Total == total)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = total}))
+                .When(s => s.Handle(new SubmitOrder { Total = total }))
                 .WhenSagaTimesOut()
                 .ExpectSend<ProcessOrder>(m => m.Total == total)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = total}));
+                .When(s => s.Handle(new SubmitOrder { Total = total }));
         }
 
 
@@ -94,7 +94,7 @@
             Test.Saga<DiscountPolicy>()
                 .ExpectSendToDestination<ProcessOrder>((m, a) => m.Total == total && a.Queue == "remote.orderQueue")
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = total, IsRemoteOrder = true}));
+                .When(s => s.Handle(new SubmitOrder { Total = total, IsRemoteOrder = true }));
         }
 
         [Test]
@@ -103,7 +103,7 @@
             decimal total = 100;
 
             Test.Saga<DiscountPolicy>()
-                .ExpectSendToDestination<ProcessOrder>((m, a) => 
+                .ExpectSendToDestination<ProcessOrder>((m, a) =>
                 {
                     Assert.That(() => m.Total, Is.EqualTo(total));
                     Assert.That(() => a.Queue, Is.EqualTo("remote.orderQueue"));
@@ -118,17 +118,17 @@
             Test.Saga<DiscountPolicy>()
                 .ExpectSend<ProcessOrder>(m => m.Total == 500)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = 500}))
+                .When(s => s.Handle(new SubmitOrder { Total = 500 }))
                 .ExpectSend<ProcessOrder>(m => m.Total == 400)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = 400}))
-                .ExpectSend<ProcessOrder>(m => m.Total == 300*(decimal) 0.9)
+                .When(s => s.Handle(new SubmitOrder { Total = 400 }))
+                .ExpectSend<ProcessOrder>(m => m.Total == 300 * (decimal)0.9)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = 300}))
+                .When(s => s.Handle(new SubmitOrder { Total = 300 }))
                 .WhenSagaTimesOut()
                 .ExpectSend<ProcessOrder>(m => m.Total == 200)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When(s => s.Handle(new SubmitOrder {Total = 200}));
+                .When(s => s.Handle(new SubmitOrder { Total = 200 }));
         }
 
         [Test]
@@ -172,14 +172,26 @@
         }
 
         [Test]
-        public void ShouldPassAssertSagaData()
+        public void ShouldPassAssertSagaData_specifying_saga_data_type()
         {
             var orderId = Guid.NewGuid();
             var customerId = Guid.NewGuid();
             Test.Saga<DiscountPolicy>()
                 .AssertSagaData<DiscountPolicyData>(state => state.RunningTotal == 0M)
-                .When(s => s.Handle(new SubmitOrder {CustomerId = customerId, OrderId = orderId, Total = 123.99M}))
+                .When(s => s.Handle(new SubmitOrder { CustomerId = customerId, OrderId = orderId, Total = 123.99M }))
                 .AssertSagaData<DiscountPolicyData>(state => state.CustomerId == customerId && state.RunningTotal == 123.99M);
+        }
+
+        [Test]
+        public void ShouldPassAssertSagaData_without_specifying_saga_data_type()
+        {
+            var customerId = Guid.NewGuid();
+            Test.Saga<DiscountPolicy, DiscountPolicyData>()
+                .AssertSagaData(state => state.RunningTotal == 0M)
+                .When(s => s.Handle(new SubmitOrder { CustomerId = customerId, OrderId = Guid.NewGuid(), Total = 123.99M }))
+                .AssertSagaData(state => state.CustomerId == customerId && state.RunningTotal == 123.99M)
+                .When(s => s.Handle(new SubmitOrder { CustomerId = customerId, OrderId = Guid.NewGuid(), Total = 100.00M }))
+                .AssertSagaData(state => state.CustomerId == customerId && state.RunningTotal == 223.99M);
         }
     }
 
@@ -216,7 +228,7 @@
     {
         public class MySagaDataWithInterface : ContainSagaData
         {
-            
+
         }
 
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaDataWithInterface> mapper)
@@ -263,7 +275,7 @@
         public string OriginalMessageId { get; set; }
     }
 
-    public interface StartsSagaWithInterface: IEvent
+    public interface StartsSagaWithInterface : IEvent
     {
         string Foo { get; set; }
     }
@@ -334,7 +346,7 @@
                                        {
                                            m.CustomerId = Data.CustomerId;
                                            m.OrderId = message.OrderId;
-                                           m.Total = message.Total*(decimal) 0.9;
+                                           m.Total = message.Total * (decimal)0.9;
                                        });
         }
 

--- a/src/NServiceBus.Testing.Tests/SagaTests.cs
+++ b/src/NServiceBus.Testing.Tests/SagaTests.cs
@@ -170,6 +170,17 @@
                 .ExpectNotForwardCurrentMessageTo(dest => dest == "expectedDestination")
                 .When(s => s.Handle(new StartsSaga()));
         }
+
+        [Test]
+        public void ShouldPassAssertSagaData()
+        {
+            var orderId = Guid.NewGuid();
+            var customerId = Guid.NewGuid();
+            Test.Saga<DiscountPolicy>()
+                .AssertSagaData<DiscountPolicyData>(state => state.RunningTotal == 0M)
+                .When(s => s.Handle(new SubmitOrder {CustomerId = customerId, OrderId = orderId, Total = 123.99M}))
+                .AssertSagaData<DiscountPolicyData>(state => state.CustomerId == customerId && state.RunningTotal == 123.99M);
+        }
     }
 
 

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -5,6 +5,275 @@ namespace NServiceBus.Testing
     using Saga;
 
     /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="TSaga"></typeparam>
+    /// <typeparam name="TSagaData"></typeparam>
+    public class Saga<TSaga, TSagaData> : Saga<TSaga> where TSaga : Saga, new()
+                                        where TSagaData : IContainSagaData, new()
+    {
+        internal Saga(TSaga saga, StubBus bus) : base(saga, bus)
+        {
+            Data = (TSagaData) saga.Entity;
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> When(Action<TSaga> sagaIsInvoked)
+        {
+            return (Saga<TSaga, TSagaData>) base.When(sagaIsInvoked);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> WithExternalDependencies(Action<TSaga> actionToSetUpExternalDependencies)
+        {
+            return (Saga<TSaga, TSagaData>) base.WithExternalDependencies(actionToSetUpExternalDependencies);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> WhenReceivesMessageFrom(string client)
+        {
+            return (Saga<TSaga, TSagaData>) base.WhenReceivesMessageFrom(client);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> SetIncomingHeader(string key, string value)
+        {
+            return (Saga<TSaga, TSagaData>) base.SetIncomingHeader(key, value);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> SetMessageId(string messageId)
+        {
+            return (Saga<TSaga, TSagaData>) base.SetMessageId(messageId);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectSend<TMessage>(Func<TMessage, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectSend(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectSend<TMessage>(Action<TMessage> check)
+        {
+            return (Saga<TSaga, TSagaData>)base.ExpectSend(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNotSend<TMessage>(Func<TMessage, bool> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNotSend(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNotSend<TMessage>(Action<TMessage> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNotSend(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectReply<TMessage>(Func<TMessage, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectReply(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectSendLocal<TMessage>(Func<TMessage, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectSendLocal(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectSendLocal<TMessage>(Action<TMessage> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectSendLocal(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNotSendLocal<TMessage>(Func<TMessage, bool> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNotSendLocal(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNotSendLocal<TMessage>(Action<TMessage> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNotSendLocal(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectSendToDestination<TMessage>(Func<TMessage, Address, bool> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectSendToDestination(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectSendToDestination<TMessage>(Action<TMessage, Address> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectSendToDestination(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNotForwardCurrentMessageTo(Func<string, bool> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNotForwardCurrentMessageTo(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectForwardCurrentMessageTo(Func<string, bool> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectForwardCurrentMessageTo(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectReplyToOriginator<TMessage>(Func<TMessage, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectReplyToOriginator(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectReplyToOriginator<TMessage>(Action<TMessage> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectReplyToOriginator(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectPublish<TMessage>(Func<TMessage, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectPublish(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectPublish<TMessage>(Action<TMessage> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectPublish(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNotPublish<TMessage>(Func<TMessage, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNotPublish(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNotPublish<TMessage>(Action<TMessage> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNotPublish(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectHandleCurrentMessageLater()
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectHandleCurrentMessageLater();
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> WhenHandling<TMessage>(Action<TMessage> initializeMessage = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.WhenHandling(initializeMessage);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> WhenSagaTimesOut()
+        {
+            return (Saga<TSaga, TSagaData>) base.WhenSagaTimesOut();
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> AssertSagaCompletionIs(bool complete)
+        {
+            return (Saga<TSaga, TSagaData>) base.AssertSagaCompletionIs(complete);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectTimeoutToBeSetIn<TMessage>(Func<TMessage, TimeSpan, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectTimeoutToBeSetIn(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNoTimeoutToBeSetIn<TMessage>(Func<TMessage, TimeSpan, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNoTimeoutToBeSetIn(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectTimeoutToBeSetIn<TMessage>(Action<TMessage, TimeSpan> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectTimeoutToBeSetIn(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectTimeoutToBeSetAt<TMessage>(Func<TMessage, DateTime, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectTimeoutToBeSetAt(check);
+        }
+
+        /// <summary>
+        /// </summary>
+        public new Saga<TSaga, TSagaData> ExpectNoTimeoutToBeSetAt<TMessage>(Func<TMessage, DateTime, bool> check = null)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectNoTimeoutToBeSetAt(check);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="check"></param>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <returns></returns>
+        public new Saga<TSaga, TSagaData> ExpectTimeoutToBeSetAt<TMessage>(Action<TMessage, DateTime> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.ExpectTimeoutToBeSetAt(check);
+        }
+
+        /// <summary>
+        /// Saga data
+        /// </summary>
+        private TSagaData Data { get; set; }
+
+        /// <summary>
+        /// Assert that the saga data contains satisfies the predicate
+        /// </summary>
+        public Saga<TSaga, TSagaData> AssertSagaData(Func<TSagaData, bool> check)
+        {
+            return (Saga<TSaga, TSagaData>) base.AssertSagaData(check);
+        }
+    }
+
+    /// <summary>
     /// Saga unit testing framework.
     /// </summary>
     public class Saga<T> where T : Saga, new()

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -354,6 +354,18 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Assert that the saga data contains satisfies the predicate
+        /// </summary>
+        public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData
+        {
+            if (check((TSagaData)saga.Entity))
+            {
+                return this;
+            }
+            throw new Exception("Assert failed. Saga data did not contain the expected values.");
+        }
+
+        /// <summary>
         /// Verifies that the saga is setting the specified timeout
         /// </summary>
         public Saga<T> ExpectTimeoutToBeSetIn<TMessage>(Func<TMessage, TimeSpan, bool> check = null)

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -356,7 +356,7 @@ namespace NServiceBus.Testing
         /// <summary>
         /// Assert that the saga data contains satisfies the predicate
         /// </summary>
-        public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData
+        public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData, new()
         {
             if (!(saga.Entity is TSagaData))
             {

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -358,6 +358,10 @@ namespace NServiceBus.Testing
         /// </summary>
         public Saga<T> AssertSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData
         {
+            if (!(saga.Entity is TSagaData))
+            {
+                throw new Exception($"Assert failed. Saga data type provided `{typeof(TSagaData)}` is not matching the actual saga type `{saga.Entity.GetType()}`");
+            }
             if (check((TSagaData)saga.Entity))
             {
                 return this;

--- a/src/NServiceBus.Testing/Test.cs
+++ b/src/NServiceBus.Testing/Test.cs
@@ -116,6 +116,35 @@
         }
 
         /// <summary>
+        /// Begin the test script for a saga of of type T and saga data of type TSagaData
+        /// </summary>
+        public static Saga<T, TSagaData> Saga<T, TSagaData>() where T : Saga, new()
+                                                              where TSagaData : IContainSagaData, new()
+        {
+            var saga = (T)Activator.CreateInstance(typeof(T));
+
+            bus = new StubBus(messageCreator);
+
+            saga.Bus = Bus;
+
+            var prop = typeof(T).GetProperty("Data");
+
+            if (prop != null)
+            {
+                var sagaData = Activator.CreateInstance(prop.PropertyType) as IContainSagaData;
+
+                saga.Entity = sagaData;
+
+                if (saga.Entity != null)
+                {
+                    saga.Entity.Id = Guid.NewGuid();
+                }
+            }
+
+            return new Saga<T, TSagaData>(saga, bus);
+        }
+
+        /// <summary>
         ///     Begin the test script for a saga of type T while specifying the saga id.
         /// </summary>
         public static Saga<T> Saga<T>(Guid sagaId) where T : Saga, new()


### PR DESCRIPTION
Allow saga state testing with fluent API using
```c#
Test.Saga<TSaga, TSagaData>
```
to be consiste with the rest of the testing API.

Example:

```c#
Test.Saga<DiscountPolicy, DiscountPolicyData>()
  .AssertSagaData(state => state.RunningTotal == 0M)
  .When(s => s.Handle(new SubmitOrder { CustomerId = customerId, OrderId = Guid.NewGuid(), Total = 123.99M }))
  .AssertSagaData(state => state.CustomerId == customerId && state.RunningTotal == 123.99M)
  .When(s => s.Handle(new SubmitOrder { CustomerId = customerId, OrderId = Guid.NewGuid(), Total = 100.00M }))
  .AssertSagaData(state => state.CustomerId == customerId && state.RunningTotal == 223.99M);
```