### PR TITLE
Expose MessageCreator for use in Test.Saga().WithExternalDependencies()

### DIFF
--- a/src/NServiceBus.Testing/FakeEncryptor.cs
+++ b/src/NServiceBus.Testing/FakeEncryptor.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Testing
 {
     using Encryption;
 
-    class FakeEncryptor : IEncryptionService
+    public class FakeEncryptor : IEncryptionService
     {
         public EncryptedValue Encrypt(string value)
         {

--- a/src/NServiceBus.Testing/Test.cs
+++ b/src/NServiceBus.Testing/Test.cs
@@ -24,6 +24,14 @@
         }
 
         /// <summary>
+        ///     Get the reference to the message creator used for testing.
+        /// </summary>
+        public static IMessageCreator MessageCreator
+        {
+            get { return messageCreator; }
+        }
+
+        /// <summary>
         ///     Initializes the testing infrastructure.
         /// </summary>
         public static void Initialize(Action<BusConfiguration> customisations = null)


### PR DESCRIPTION
NServiceBus currently injects an instance of the MessageCreator into my sagas. However, NServiceBus.Testing does not provide a way out of the box to get a copy of the MessageCreator to use in WithExternalDependencies() for testing. This change exposes the MessageCreator object on Test.cs.