### PR TITLE
remove SentToSites expectations

### DIFF
--- a/src/NServiceBus.Testing.Tests/TestHandlerFixture.cs
+++ b/src/NServiceBus.Testing.Tests/TestHandlerFixture.cs
@@ -31,22 +31,6 @@ namespace NServiceBus.Testing.Tests
         }
 
         [Test]
-        public void ShouldFailAssertingSendToSitesWasCalled()
-        {
-            Assert.Throws<Exception>(() => Test.Handler<EmptyHandler>()
-                .ExpectSendToSites<TestMessage>((m, a) => true)
-                .OnMessage<TestMessage>());
-        }
-
-        [Test]
-        public void ShouldAssertSendToSitesWasNotCalled()
-        {
-            Test.Handler<EmptyHandler>()
-                .ExpectNotSendToSites<TestMessage>((m, a) => true)
-                .OnMessage<TestMessage>();
-        }
-
-        [Test]
         public void ShouldAssertDeferWasCalledWithTimeSpan()
         {
             var timespan = TimeSpan.FromMinutes(10);

--- a/src/NServiceBus.Testing/Handler.cs
+++ b/src/NServiceBus.Testing/Handler.cs
@@ -155,24 +155,6 @@
         }
 
         /// <summary>
-        /// Check that the handler sends a message of the given type to sites.
-        /// </summary>
-        public Handler<T> ExpectSendToSites<TMessage>(Func<TMessage, IEnumerable<string>, bool> check)
-        {
-            expectedInvocations.Add(new ExpectedSendToSitesInvocation<TMessage> { Check = check });
-            return this;
-        }
-
-        /// <summary>
-        /// Check that the handler doesn't send a message of the given type to sites.
-        /// </summary>
-        public Handler<T> ExpectNotSendToSites<TMessage>(Func<TMessage, IEnumerable<string>, bool> check)
-        {
-            expectedInvocations.Add(new ExpectedNotSendToSitesInvocation<TMessage> { Check = check });
-            return this;
-        }
-
-        /// <summary>
         /// Check that the handler defers a message of the given type.
         /// </summary>
         public Handler<T> ExpectDefer<TMessage>(Func<TMessage, TimeSpan, bool> check)


### PR DESCRIPTION
It's currently not possible to call `SendToSite` in v5 using the testing framework since the extension methods from the Gateway package cast the `IBus` instance to an `UnicastBus` which fails with the fake bus from the testing framework. Therefore the expectations also don't work any more.

@Particular/nservicebus-maintainers please review