### PR TITLE
Add overloads providing access to the send options

### DIFF
--- a/src/NServiceBus.Testing.Tests/HandlerTests.cs
+++ b/src/NServiceBus.Testing.Tests/HandlerTests.cs
@@ -133,11 +133,53 @@ namespace NServiceBus.Testing.Tests
         }
 
         [Test]
+        public void ShouldPassExpectReplyProvidedOptionsToCheck()
+        {
+            var options = new ReplyOptions();
+            ReplyOptions capturedOptions = null;
+
+            Test.Handler<ReplyingHandler>()
+                .WithExternalDependencies(handler => handler.OptionsProvider = () => options)
+                .ExpectReply<MyReply>((reply, replyOptions) =>
+                {
+                    capturedOptions = replyOptions;
+                    return true;
+                })
+                .OnMessage(new MyRequest
+                {
+                    ShouldReply = true
+                });
+
+            Assert.AreSame(options, capturedOptions);
+        }
+
+        [Test]
         public void ShouldNotReplyWhenReceivingAWrongMessage()
         {
             Test.Handler<ReplyingHandler>()
                 .ExpectNotReply<MyReply>(reply => reply == null)
                 .OnMessage(new MyRequest { ShouldReply = false });
+        }
+
+        [Test]
+        public void ShouldPassExpectNotReplyProvidedOptionsToCheck()
+        {
+            var options = new ReplyOptions();
+            ReplyOptions capturedOptions = null;
+
+            Test.Handler<ReplyingHandler>()
+                .WithExternalDependencies(handler => handler.OptionsProvider = () => options)
+                .ExpectNotReply<MyReply>((reply, replyOptions) =>
+                {
+                    capturedOptions = replyOptions;
+                    return false;
+                })
+                .OnMessage(new MyRequest
+                {
+                    ShouldReply = true
+                });
+
+            Assert.AreSame(options, capturedOptions);
         }
 
         [Test]
@@ -177,7 +219,7 @@ namespace NServiceBus.Testing.Tests
         public void ShouldPassExpectPublishWhenPublishingAndCheckingPredicate()
         {
             Test.Handler<PublishingHandler<Publish1>>()
-                .WithExternalDependencies(h => h.ModifyPublish = m => m.Data = "Data")
+                .WithExternalDependencies(h => h.ModifyMessage = m => m.Data = "Data")
                 .ExpectPublish<Publish1>(m => m.Data == "Data")
                 .OnMessage<TestMessage>();
         }
@@ -186,7 +228,7 @@ namespace NServiceBus.Testing.Tests
         public void ShouldFailExpectNotPublishWhenPublishingAndCheckingPredicate()
         {
             Assert.Throws<Exception>(() => Test.Handler<PublishingHandler<Publish1>>()
-                .WithExternalDependencies(h => h.ModifyPublish = m => m.Data = "Data")
+                .WithExternalDependencies(h => h.ModifyMessage = m => m.Data = "Data")
                 .ExpectNotPublish<Publish1>(m => m.Data == "Data")
                 .OnMessage<TestMessage>());
         }
@@ -195,7 +237,7 @@ namespace NServiceBus.Testing.Tests
         public void ShouldFailExpectPublishWhenPublishingAndCheckingPredicateThatFails()
         {
             Assert.Throws<Exception>(() => Test.Handler<PublishingHandler<Publish1>>()
-                .WithExternalDependencies(h => h.ModifyPublish = m => m.Data = "NotData")
+                .WithExternalDependencies(h => h.ModifyMessage = m => m.Data = "NotData")
                 .ExpectPublish<Publish1>(m => m.Data == "Data")
                 .OnMessage<TestMessage>());
         }
@@ -204,7 +246,7 @@ namespace NServiceBus.Testing.Tests
         public void ShouldPassExpectNotPublishWhenPublishingAndCheckingPredicateThatFails()
         {
             Test.Handler<PublishingHandler<Publish1>>()
-                .WithExternalDependencies(h => h.ModifyPublish = m => m.Data = "NotData")
+                .WithExternalDependencies(h => h.ModifyMessage = m => m.Data = "NotData")
                 .ExpectNotPublish<Publish1>(m => m.Data == "Data")
                 .OnMessage<TestMessage>();
         }
@@ -218,11 +260,47 @@ namespace NServiceBus.Testing.Tests
         }
 
         [Test]
+        public void ShouldPassExpectPublishProvidedPublishOptionsToCheck()
+        {
+            var options = new PublishOptions();
+            PublishOptions capturedOptions = null;
+
+            Test.Handler<PublishingHandler<Publish1>>()
+                .WithExternalDependencies(h => h.OptionsProvider = () => options)
+                .ExpectPublish<Publish1>((message, publishOptions) =>
+                {
+                    capturedOptions = publishOptions;
+                    return true;
+                })
+                .OnMessage<TestMessage>();
+
+            Assert.AreSame(options, capturedOptions);
+        }
+
+        [Test]
         public void ShouldPassExpectNotPublishIfNotPublishing()
         {
             Test.Handler<EmptyHandler>()
                 .ExpectNotPublish<Publish1>(m => true)
                 .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldPassExpectNotPublishProvidedPublishOptionsToCheck()
+        {
+            var options = new PublishOptions();
+            PublishOptions capturedOptions = null;
+
+            Test.Handler<PublishingHandler<Publish1>>()
+                .WithExternalDependencies(h => h.OptionsProvider = () => options)
+                .ExpectNotPublish<Publish1>((message, publishOptions) =>
+                {
+                    capturedOptions = publishOptions;
+                    return false;
+                })
+                .OnMessage<TestMessage>();
+
+            Assert.AreSame(options, capturedOptions);
         }
 
         [Test]
@@ -250,6 +328,24 @@ namespace NServiceBus.Testing.Tests
         }
 
         [Test]
+        public void ShouldPassExpectSendProvidedSendOptionsToCheck()
+        {
+            var options = new SendOptions();
+            SendOptions capturedOptions = null;
+
+            Test.Handler<SendingHandler<Send1>>()
+                .WithExternalDependencies(handler => handler.OptionsProvider = () => options)
+                .ExpectSend<Send1>((message, sendOptions) =>
+                {
+                    capturedOptions = sendOptions;
+                    return true;
+                })
+                .OnMessage<TestMessage>();
+
+            Assert.AreSame(options, capturedOptions);
+        }
+
+        [Test]
         public void ShouldPassExpectNotSendIfNotSending()
         {
             Test.Handler<EmptyHandler>()
@@ -263,6 +359,24 @@ namespace NServiceBus.Testing.Tests
             Assert.Throws<Exception>(() => Test.Handler<SendingHandler<Send1>>()
                 .ExpectNotSend<Send1>(m => true)
                 .OnMessage<TestMessage>());
+        }
+
+        [Test]
+        public void ShouldPassExpectNotSentProvidedSendOptionsToCheck()
+        {
+            var options = new SendOptions();
+            SendOptions capturedOptions = null;
+
+            Test.Handler<SendingHandler<Send1>>()
+                .WithExternalDependencies(handler => handler.OptionsProvider = () => options)
+                .ExpectNotSend<Send1>((message, sendOptions) =>
+                {
+                    capturedOptions = sendOptions;
+                    return false;
+                })
+                .OnMessage<TestMessage>();
+
+            Assert.AreSame(options, capturedOptions);
         }
 
         [Test]
@@ -624,11 +738,13 @@ namespace NServiceBus.Testing.Tests
         public class SendingHandler<TSend> : IHandleMessages<TestMessage>
             where TSend : IMessage
         {
-            public Action<TSend> ModifyPublish { get; set; } = m => { };
+            public Action<TSend> ModifyMessage { get; set; } = m => { };
+
+            public Func<SendOptions> OptionsProvider { get; set; } = () => new SendOptions();
 
             public Task Handle(TestMessage message, IMessageHandlerContext context)
             {
-                return context.Send(ModifyPublish);
+                return context.Send(ModifyMessage, OptionsProvider());
             }
         }
 
@@ -646,11 +762,13 @@ namespace NServiceBus.Testing.Tests
         public class PublishingHandler<TPublish> : IHandleMessages<TestMessage>
             where TPublish : IMessage
         {
-            public Action<TPublish> ModifyPublish { get; set; } = m => { };
+            public Action<TPublish> ModifyMessage { get; set; } = m => { };
+
+            public Func<PublishOptions> OptionsProvider { get; set; } = () => new PublishOptions();
 
             public Task Handle(TestMessage message, IMessageHandlerContext context)
             {
-                return context.Publish(ModifyPublish);
+                return context.Publish(ModifyMessage, OptionsProvider());
             }
         }
 
@@ -740,9 +858,11 @@ namespace NServiceBus.Testing.Tests
 
         public class ReplyingHandler : IHandleMessages<MyRequest>
         {
+            public Func<ReplyOptions> OptionsProvider { get; set; } = () => new ReplyOptions();
+
             public Task Handle(MyRequest message, IMessageHandlerContext context)
             {
-                return message.ShouldReply ? context.Reply(new MyReply()) : Task.FromResult(0);
+                return message.ShouldReply ? context.Reply(new MyReply(), OptionsProvider()) : Task.FromResult(0);
             }
         }
     }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotPublish.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotPublish.cs
@@ -3,16 +3,16 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System;
     using System.Collections.Generic;
 
-    class ExpectNotPublish<TMessage> : ExpectedNotMessageInvocation<TMessage>
+    class ExpectNotPublish<TMessage> : ExpectedNotMessageInvocation<TMessage, PublishOptions>
     {
-        public ExpectNotPublish(Func<TMessage, bool> check)
+        public ExpectNotPublish(Func<TMessage, PublishOptions, bool> check)
             : base(check)
         {
         }
 
-        protected override List<TMessage> GetMessages(TestableMessageHandlerContext context)
+        protected override IEnumerable<OutgoingMessage<TMessage, PublishOptions>> GetMessages(TestableMessageHandlerContext context)
         {
-            return context.PublishedMessages.GetMessages<TMessage>();
+            return context.PublishedMessages.Containing<TMessage>();
         }
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotReply.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotReply.cs
@@ -3,16 +3,16 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System;
     using System.Collections.Generic;
 
-    class ExpectNotReply<TMessage> : ExpectedNotMessageInvocation<TMessage>
+    class ExpectNotReply<TMessage> : ExpectedNotMessageInvocation<TMessage, ReplyOptions>
     {
-        public ExpectNotReply(Func<TMessage, bool> check)
+        public ExpectNotReply(Func<TMessage, ReplyOptions, bool> check)
             : base(check)
         {
         }
 
-        protected override List<TMessage> GetMessages(TestableMessageHandlerContext context)
+        protected override IEnumerable<OutgoingMessage<TMessage, ReplyOptions>> GetMessages(TestableMessageHandlerContext context)
         {
-            return context.RepliedMessages.GetMessages<TMessage>();
+            return context.RepliedMessages.Containing<TMessage>();
         }
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotSend.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotSend.cs
@@ -3,16 +3,16 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System;
     using System.Collections.Generic;
 
-    class ExpectNotSend<TMessage> : ExpectedNotMessageInvocation<TMessage>
+    class ExpectNotSend<TMessage> : ExpectedNotMessageInvocation<TMessage, SendOptions>
     {
-        public ExpectNotSend(Func<TMessage, bool> check)
+        public ExpectNotSend(Func<TMessage, SendOptions, bool> check)
             : base(check)
         {
         }
 
-        protected override List<TMessage> GetMessages(TestableMessageHandlerContext context)
+        protected override IEnumerable<OutgoingMessage<TMessage, SendOptions>> GetMessages(TestableMessageHandlerContext context)
         {
-            return context.SentMessages.GetMessages<TMessage>();
+            return context.SentMessages.Containing<TMessage>();
         }
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectPublish.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectPublish.cs
@@ -3,16 +3,16 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System;
     using System.Collections.Generic;
 
-    class ExpectPublish<TMessage> : ExpectedMessageInvocation<TMessage>
+    class ExpectPublish<TMessage> : ExpectedMessageInvocation<TMessage, PublishOptions>
     {
-        public ExpectPublish(Func<TMessage, bool> check)
+        public ExpectPublish(Func<TMessage, PublishOptions, bool> check)
             : base(check)
         {
         }
 
-        protected override List<TMessage> GetMessages(TestableMessageHandlerContext context)
+        protected override IEnumerable<OutgoingMessage<TMessage, PublishOptions>> GetMessages(TestableMessageHandlerContext context)
         {
-            return context.PublishedMessages.GetMessages<TMessage>();
+            return context.PublishedMessages.Containing<TMessage>();
         }
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectReply.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectReply.cs
@@ -3,16 +3,16 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System;
     using System.Collections.Generic;
 
-    class ExpectReply<TMessage> : ExpectedMessageInvocation<TMessage>
+    class ExpectReply<TMessage> : ExpectedMessageInvocation<TMessage, ReplyOptions>
     {
-        public ExpectReply(Func<TMessage, bool> check)
+        public ExpectReply(Func<TMessage, ReplyOptions, bool> check)
             : base(check)
         {
         }
 
-        protected override List<TMessage> GetMessages(TestableMessageHandlerContext context)
+        protected override IEnumerable<OutgoingMessage<TMessage, ReplyOptions>> GetMessages(TestableMessageHandlerContext context)
         {
-            return context.RepliedMessages.GetMessages<TMessage>();
+            return context.RepliedMessages.Containing<TMessage>();
         }
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectSend.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectSend.cs
@@ -3,16 +3,15 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System;
     using System.Collections.Generic;
 
-    class ExpectSend<TMessage> : ExpectedMessageInvocation<TMessage>
+    class ExpectSend<TMessage> : ExpectedMessageInvocation<TMessage, SendOptions>
     {
-        public ExpectSend(Func<TMessage, bool> check)
-            : base(check)
+        public ExpectSend(Func<TMessage, SendOptions, bool> check) : base(check)
         {
         }
 
-        protected override List<TMessage> GetMessages(TestableMessageHandlerContext context)
+        protected override IEnumerable<OutgoingMessage<TMessage, SendOptions>> GetMessages(TestableMessageHandlerContext context)
         {
-            return context.SentMessages.GetMessages<TMessage>();
+            return context.SentMessages.Containing<TMessage>();
         }
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectedMessageInvocation.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectedMessageInvocation.cs
@@ -4,27 +4,27 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System.Collections.Generic;
     using System.Linq;
 
-    abstract class ExpectedMessageInvocation<TMessage> : ExpectInvocation
+    abstract class ExpectedMessageInvocation<TMessage, TOptions> : ExpectInvocation
     {
-        protected ExpectedMessageInvocation(Func<TMessage, bool> check)
+        protected ExpectedMessageInvocation(Func<TMessage, TOptions, bool> check)
         {
-            this.check = check ?? (message => true);
+            this.check = check ?? ((message, options) => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)
         {
-            var invokedMessages = GetMessages(context);
+            var invokedMessages = GetMessages(context).ToList();
 
-            if (invokedMessages.Any(invokedMessage => check(invokedMessage)))
+            if (invokedMessages.Any(invokedMessage => check(invokedMessage.Message, invokedMessage.Options)))
             {
                 return;
             }
 
-            Fail(invokedMessages);
+            Fail(invokedMessages.Select(x => x.Message));
         }
 
-        protected abstract List<TMessage> GetMessages(TestableMessageHandlerContext context);
+        protected abstract IEnumerable<OutgoingMessage<TMessage, TOptions>> GetMessages(TestableMessageHandlerContext context);
 
-        readonly Func<TMessage, bool> check;
+        readonly Func<TMessage, TOptions, bool> check;
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectedNotMessageInvocation.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectedNotMessageInvocation.cs
@@ -4,25 +4,25 @@ namespace NServiceBus.Testing.ExpectedInvocations
     using System.Collections.Generic;
     using System.Linq;
 
-    abstract class ExpectedNotMessageInvocation<TMessage> : ExpectInvocation
+    abstract class ExpectedNotMessageInvocation<TMessage, TOptions> : ExpectInvocation
     {
-        protected ExpectedNotMessageInvocation(Func<TMessage, bool> check)
+        protected ExpectedNotMessageInvocation(Func<TMessage, TOptions, bool> check)
         {
-            this.check = check ?? (message => true);
+            this.check = check ?? ((message, options) => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)
         {
-            var invokedMessages = GetMessages(context);
+            var invokedMessages = GetMessages(context).ToList();
 
-            if (invokedMessages.Any(invokedMessage => check(invokedMessage)))
+            if (invokedMessages.Any(invokedMessage => check(invokedMessage.Message, invokedMessage.Options)))
             {
-                Fail(invokedMessages);
+                Fail(invokedMessages.Select(x => x.Message));
             }
         }
 
-        protected abstract List<TMessage> GetMessages(TestableMessageHandlerContext context);
+        protected abstract IEnumerable<OutgoingMessage<TMessage, TOptions>> GetMessages(TestableMessageHandlerContext context);
 
-        readonly Func<TMessage, bool> check;
+        readonly Func<TMessage, TOptions, bool> check;
     }
 }

--- a/src/NServiceBus.Testing/Handler.cs
+++ b/src/NServiceBus.Testing/Handler.cs
@@ -52,9 +52,26 @@
         /// <summary>
         /// Check that the handler sends a message of the given type complying with the given predicate.
         /// </summary>
-        public Handler<T> ExpectSend<TMessage>(Func<TMessage, bool> check)
+        public Handler<T> ExpectSend<TMessage>(Func<TMessage, SendOptions, bool> check)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectSend<TMessage>(check));
+            return this;
+        }
+
+        /// <summary>
+        /// Check that the handler sends a message of the given type complying with the given predicate.
+        /// </summary>
+        public Handler<T> ExpectSend<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectSend((TMessage m, SendOptions _) => check(m));
+        }
+
+        /// <summary>
+        /// Check that the handler does not send a message of the given type complying with the given predicate.
+        /// </summary>
+        public Handler<T> ExpectNotSend<TMessage>(Func<TMessage, SendOptions, bool> check)
+        {
+            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotSend<TMessage>(check));
             return this;
         }
 
@@ -63,7 +80,15 @@
         /// </summary>
         public Handler<T> ExpectNotSend<TMessage>(Func<TMessage, bool> check)
         {
-            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotSend<TMessage>(check));
+            return ExpectNotSend((TMessage m, SendOptions _) => check(m));
+        }
+
+        /// <summary>
+        /// Check that the handler does not reply with a given message
+        /// </summary>
+        public Handler<T> ExpectNotReply<TMessage>(Func<TMessage, ReplyOptions, bool> check)
+        {
+            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotReply<TMessage>(check));
             return this;
         }
 
@@ -72,7 +97,15 @@
         /// </summary>
         public Handler<T> ExpectNotReply<TMessage>(Func<TMessage, bool> check)
         {
-            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotReply<TMessage>(check));
+            return ExpectNotReply((TMessage m, ReplyOptions _) => check(m));
+        }
+
+        /// <summary>
+        /// Check that the handler replies with the given message type complying with the given predicate.
+        /// </summary>
+        public Handler<T> ExpectReply<TMessage>(Func<TMessage, ReplyOptions, bool> check)
+        {
+            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectReply<TMessage>(check));
             return this;
         }
 
@@ -81,8 +114,7 @@
         /// </summary>
         public Handler<T> ExpectReply<TMessage>(Func<TMessage, bool> check)
         {
-            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectReply<TMessage>(check));
-            return this;
+            return ExpectReply((TMessage m, ReplyOptions _) => check(m));
         }
 
         /// <summary>
@@ -107,9 +139,26 @@
         /// <summary>
         /// Check that the handler publishes a message of the given type complying with the given predicate.
         /// </summary>
-        public Handler<T> ExpectPublish<TMessage>(Func<TMessage, bool> check)
+        public Handler<T> ExpectPublish<TMessage>(Func<TMessage, PublishOptions, bool> check)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectPublish<TMessage>(check));
+            return this;
+        }
+
+        /// <summary>
+        /// Check that the handler publishes a message of the given type complying with the given predicate.
+        /// </summary>
+        public Handler<T> ExpectPublish<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectPublish((TMessage m, PublishOptions _) => check(m));
+        }
+
+        /// <summary>
+        /// Check that the handler does not publish any messages of the given type complying with the given predicate.
+        /// </summary>
+        public Handler<T> ExpectNotPublish<TMessage>(Func<TMessage, PublishOptions, bool> check)
+        {
+            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotPublish<TMessage>(check));
             return this;
         }
 
@@ -118,8 +167,7 @@
         /// </summary>
         public Handler<T> ExpectNotPublish<TMessage>(Func<TMessage, bool> check)
         {
-            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotPublish<TMessage>(check));
-            return this;
+            return ExpectNotPublish((TMessage m, PublishOptions _) => check(m));
         }
 
         /// <summary>

--- a/src/NServiceBus.Testing/InvokedMessageExtensions.cs
+++ b/src/NServiceBus.Testing/InvokedMessageExtensions.cs
@@ -5,34 +5,25 @@
 
     internal static class InvokedMessageExtensions
     {
-        public static List<RepliedMessage<TMessage>> Containing<TMessage>(this IEnumerable<RepliedMessage<object>> repliedMessages)
+        public static IEnumerable<RepliedMessage<TMessage>> Containing<TMessage>(this IEnumerable<RepliedMessage<object>> repliedMessages)
         {
-            return repliedMessages.Where(x => x.Message is TMessage).Select(x => new RepliedMessage<TMessage>((TMessage)x.Message, x.Options)).ToList();
+            return repliedMessages
+                .Where(x => x.Message is TMessage)
+                .Select(x => new RepliedMessage<TMessage>((TMessage)x.Message, x.Options));
         }
 
-        public static List<PublishedMessage<TMessage>> Containing<TMessage>(this IEnumerable<PublishedMessage<object>> publishedMessages)
+        public static IEnumerable<PublishedMessage<TMessage>> Containing<TMessage>(this IEnumerable<PublishedMessage<object>> publishedMessages)
         {
-            return publishedMessages.Where(x => x.Message is TMessage).Select(x => new PublishedMessage<TMessage>((TMessage) x.Message, x.Options)).ToList();
+            return publishedMessages
+                .Where(x => x.Message is TMessage)
+                .Select(x => new PublishedMessage<TMessage>((TMessage) x.Message, x.Options));
         }
 
-        public static List<SentMessage<TMessage>> Containing<TMessage>(this IEnumerable<SentMessage<object>> sentMessages)
+        public static IEnumerable<SentMessage<TMessage>> Containing<TMessage>(this IEnumerable<SentMessage<object>> sentMessages)
         {
-            return sentMessages.Where(x => x.Message is TMessage).Select(x => new SentMessage<TMessage>((TMessage) x.Message, x.Options)).ToList();
-        }
-
-        public static List<TMessage> GetMessages<TMessage>(this IEnumerable<RepliedMessage<object>> repliedMessages)
-        {
-            return repliedMessages.Select(x => x.Message).OfType<TMessage>().ToList();
-        }
-
-        public static List<TMessage> GetMessages<TMessage>(this IEnumerable<SentMessage<object>> sentMessages)
-        {
-            return sentMessages.Select(x => x.Message).OfType<TMessage>().ToList();
-        }
-
-        public static List<TMessage> GetMessages<TMessage>(this IEnumerable<PublishedMessage<object>> publishedMessage)
-        {
-            return publishedMessage.Select(x => x.Message).OfType<TMessage>().ToList();
+            return sentMessages
+                .Where(x => x.Message is TMessage)
+                .Select(x => new SentMessage<TMessage>((TMessage) x.Message, x.Options));
         }
     }
 }

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -63,10 +63,18 @@
         /// <summary>
         /// Check that the saga sends a message of the given type complying with the given predicate.
         /// </summary>
-        public Saga<T> ExpectSend<TMessage>(Func<TMessage, bool> check = null)
+        public Saga<T> ExpectSend<TMessage>(Func<TMessage, SendOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectSend<TMessage>(check));
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga sends a message of the given type complying with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectSend<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectSend((TMessage m, SendOptions _) => check(m));
         }
 
         /// <summary>
@@ -81,10 +89,18 @@
         /// <summary>
         /// Check that the saga does not send a message of the given type complying with the given predicate.
         /// </summary>
-        public Saga<T> ExpectNotSend<TMessage>(Func<TMessage, bool> check)
+        public Saga<T> ExpectNotSend<TMessage>(Func<TMessage, SendOptions, bool> check)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotSend<TMessage>(check));
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga does not send a message of the given type complying with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectNotSend<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectNotSend((TMessage m, SendOptions _) => check(m));
         }
 
         /// <summary>
@@ -99,10 +115,18 @@
         /// <summary>
         /// Check that the saga replies with the given message type complying with the given predicate.
         /// </summary>
-        public Saga<T> ExpectReply<TMessage>(Func<TMessage, bool> check = null)
+        public Saga<T> ExpectReply<TMessage>(Func<TMessage, ReplyOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectReply<TMessage>(check));
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga replies with the given message type complying with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectReply<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectReply((TMessage m, ReplyOptions _) => check(m));
         }
         
         /// <summary>
@@ -144,10 +168,18 @@
         /// <summary>
         /// Check that the saga publishes a message of the given type complying with the given predicate.
         /// </summary>
-        public Saga<T> ExpectPublish<TMessage>(Func<TMessage, bool> check = null)
+        public Saga<T> ExpectPublish<TMessage>(Func<TMessage, PublishOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectPublish<TMessage>(check));
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga publishes a message of the given type complying with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectPublish<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectPublish((TMessage m, PublishOptions _) => check(m));
         }
 
         /// <summary>
@@ -162,10 +194,18 @@
         /// <summary>
         /// Check that the saga does not publish any messages of the given type complying with the given predicate.
         /// </summary>
-        public Saga<T> ExpectNotPublish<TMessage>(Func<TMessage, bool> check = null)
+        public Saga<T> ExpectNotPublish<TMessage>(Func<TMessage, PublishOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotPublish<TMessage>(check));
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga does not publish any messages of the given type complying with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectNotPublish<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectNotPublish((TMessage m, PublishOptions _) => check(m));
         }
 
         /// <summary>

--- a/src/NServiceBus.Testing/TestableMessageHandlerContext.cs
+++ b/src/NServiceBus.Testing/TestableMessageHandlerContext.cs
@@ -121,42 +121,36 @@ namespace NServiceBus.Testing
         IMessageCreator messageCreator;
     }
 
-    internal class SentMessage<TMessage>
+    internal class OutgoingMessage<TMessage, TOptions>
     {
-        internal SentMessage(TMessage message, SendOptions options)
+        public OutgoingMessage(TMessage message, TOptions options)
         {
             Message = message;
             Options = options;
         }
 
-        internal TMessage Message { get; private set; }
-
-        internal SendOptions Options { get; private set; }
+        public TMessage Message { get; }
+        public TOptions Options { get; }
     }
 
-    internal class PublishedMessage<TMessage>
+    internal class SentMessage<TMessage> : OutgoingMessage<TMessage, SendOptions>
     {
-        internal PublishedMessage(TMessage message, PublishOptions options)
+        internal SentMessage(TMessage message, SendOptions options) : base(message, options)
         {
-            Message = message;
-            Options = options;
         }
-
-        internal TMessage Message { get; private set; }
-
-        internal PublishOptions Options { get; private set; }
     }
 
-    internal class RepliedMessage<TMessage>
+    internal class PublishedMessage<TMessage> : OutgoingMessage<TMessage, PublishOptions>
     {
-        internal RepliedMessage(TMessage message, ReplyOptions options)
+        internal PublishedMessage(TMessage message, PublishOptions options) : base(message, options)
         {
-            Message = message;
-            Options = options;
         }
+    }
 
-        internal TMessage Message { get; private set; }
-
-        internal ReplyOptions Options { get; private set; }
+    internal class RepliedMessage<TMessage> : OutgoingMessage<TMessage, ReplyOptions>
+    {
+        internal RepliedMessage(TMessage message, ReplyOptions options) : base(message, options)
+        {
+        }
     }
 }


### PR DESCRIPTION
Adds overloads to `ExpectSend` `ExpectPublish` and `ExpectReply` (incl. ExpectNot options) which provide the specific send/publish/reply option so users can verify the options themselves.

This is e.g. required for users to be able to verify options provided by downstream repos like Gateway or Callbacks.

e.g. something like  `ExpectSend<MyMessage>((message, options) => options.GetSite() == "expected site")`

Connects to #29