### PR TITLE
Remove empty ctor requirement for sagas

### DIFF
--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.Testing
     /// <summary>
     /// Saga unit testing framework.
     /// </summary>
-    public class Saga<T> where T : Saga, new()
+    public class Saga<T> where T : Saga
     {
         private readonly T saga;
         private readonly StubBus bus;

--- a/src/NServiceBus.Testing/Test.cs
+++ b/src/NServiceBus.Testing/Test.cs
@@ -143,7 +143,7 @@
         ///     Begin the test script for the passed in saga instance.
         ///     Callers need to instantiate the saga's data class as well as give it an ID.
         /// </summary>
-        public static Saga<T> Saga<T>(T saga) where T : Saga, new()
+        public static Saga<T> Saga<T>(T saga) where T : Saga
         {
             bus = new StubBus(messageCreator);
 


### PR DESCRIPTION
Remove the `new()` constraint for testable sagas in cases the user already provides an instance of the saga.