### PR TITLE
When overloads for handler selection

### DIFF
--- a/src/NServiceBus.Testing.Tests/SagaTests.cs
+++ b/src/NServiceBus.Testing.Tests/SagaTests.cs
@@ -59,10 +59,7 @@
                 }, c))
                 .ExpectSend<ProcessOrder>(m => m.Total == total * (decimal)0.9)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When((s, c) => s.Handle(new SubmitOrder
-                {
-                    Total = total
-                }, c));
+                .When<SubmitOrder>(s => s.Handle, m => m.Total = total);
         }
 
         [Test]
@@ -72,10 +69,7 @@
 
             Test.Saga<DiscountPolicy>()
                 .ExpectSend<ProcessOrder>(m => Assert.That(() => m.Total, Is.EqualTo(total)))
-                .When((s, c) => s.Handle(new SubmitOrder
-                {
-                    Total = total
-                }, c));
+                .When<SubmitOrder>(s => s.Handle, m => m.Total = total);
         }
 
         [Test]
@@ -93,10 +87,10 @@
                 .WhenHandlingTimeout<SubmitOrder>(m => m.Total = total)
                 .ExpectSend<ProcessOrder>(m => m.Total == total)
                 .ExpectTimeoutToBeSetIn<SubmitOrder>((state, span) => span == TimeSpan.FromDays(7))
-                .When((s, c) => s.Handle(new SubmitOrder
+                .When(s => s.Handle, new SubmitOrder
                 {
                     Total = total
-                }, c));
+                });
         }
 
         [Test]

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -264,6 +264,24 @@
         }
 
         /// <summary>
+        /// Uses the given delegate to select the message handler and invoking it with the given message. Checks all the expectations previously, and then clearing them for continued testing.
+        /// </summary>
+        public Saga<T> When<TMessage>(Func<T, Func<TMessage, IMessageHandlerContext, Task>> handlerSelector, TMessage message)
+        {
+            return When((s, context) => handlerSelector(s)(message, context));
+        }
+
+        /// <summary>
+        /// Uses the given delegate to select the message handler and invoking it with the specified message. Checks all the expectations previously, and then clearing them for continued testing.
+        /// </summary>
+        public Saga<T> When<TMessage>(Func<T, Func<TMessage, IMessageHandlerContext, Task>> handlerSelector, Action<TMessage> messageInitializer = null)
+        {
+            var message = (TMessage) messageCreator.CreateInstance(typeof(TMessage));
+            messageInitializer?.Invoke(message);
+            return When((s, context) => handlerSelector(s)(message, context));
+        }
+
+        /// <summary>
         /// Invokes the saga timeout passing in the last timeout state it sent
         /// and then clears out all previous expectations.
         /// </summary>

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -252,6 +252,7 @@
         /// <summary>
         /// Uses the given delegate to invoke the saga, checking all the expectations previously set up,
         /// and then clearing them for continued testing.
+        /// example: <c>When((saga, context) => s.Handle(new MyMessage(), context))</c>
         /// </summary>
         public Saga<T> When(Func<T, IMessageHandlerContext, Task> sagaIsInvoked)
         {
@@ -265,6 +266,7 @@
 
         /// <summary>
         /// Uses the given delegate to select the message handler and invoking it with the given message. Checks all the expectations previously, and then clearing them for continued testing.
+        /// example: <c>When(s => s.Handle, new MyMessage())</c>
         /// </summary>
         public Saga<T> When<TMessage>(Func<T, Func<TMessage, IMessageHandlerContext, Task>> handlerSelector, TMessage message)
         {
@@ -273,6 +275,7 @@
 
         /// <summary>
         /// Uses the given delegate to select the message handler and invoking it with the specified message. Checks all the expectations previously, and then clearing them for continued testing.
+        /// example: <c>When&lt;MyMessage>(s => s.Handle, m => { m.Value = 42 })</c>
         /// </summary>
         public Saga<T> When<TMessage>(Func<T, Func<TMessage, IMessageHandlerContext, Task>> handlerSelector, Action<TMessage> messageInitializer = null)
         {


### PR DESCRIPTION
Connects to #29 

Adds overloads to `When` (used in Saga tests for handler invocation). Instead of writing

```.When((s, c) => s.Handle(new SubmitOrder
                {
                    Total = total,
                    IsRemoteOrder = true
                }, c))````

you can now write

```.When<SubmitOrder>(s => s.Handle, m => m.Total = total);````

or 

```.When(s => s.Handle, new SubmitOrder{ Total = total })```

Note that `When` didn't support interface-only messages yet and used `.WhenHandling<IMessage>(m => [...])` instead.

@Particular/nservicebus-maintainers @hmemcpy @mat-mcloughlin please review