### PR TITLE
Make TestableHandlerContext operations threadsafe

### DIFF
--- a/src/NServiceBus.Testing/InvokedMessageExtensions.cs
+++ b/src/NServiceBus.Testing/InvokedMessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Testing
+namespace NServiceBus.Testing
 {
     using System.Collections.Generic;
     using System.Linq;


### PR DESCRIPTION
Make sure operations like `Send` `Publish` and so on are threadsafe. Since the TestableHandlerContext class isn't public (yet) we can't directly test the class, so the tests are currently placed on the handler tests.

Connects to #29 