### PR TITLE
Adding the ability to seed saga data

### DIFF
--- a/src/NServiceBus.Testing.Tests/NServiceBus.Testing.Tests.csproj
+++ b/src/NServiceBus.Testing.Tests/NServiceBus.Testing.Tests.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="SagaTests.cs" />
     <Compile Include="HandlerTests.cs" />
+    <Compile Include="Saga\SagaDataTests.cs" />
     <Compile Include="Saga\SagaTimeoutTests.cs" />
     <Compile Include="Timeouts.cs" />
   </ItemGroup>

--- a/src/NServiceBus.Testing.Tests/Saga/SagaDataTests.cs
+++ b/src/NServiceBus.Testing.Tests/Saga/SagaDataTests.cs
@@ -1,0 +1,72 @@
+﻿namespace NServiceBus.Testing.Tests.Saga
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class SagaDataTests
+    {
+        [Test]
+        public void ShouldCreateSagaWithSagaData()
+        {
+            Test.Saga<SagaCreation>(new SagaCreation.CreationData { Property = "property" })
+                .ExpectSagaData<SagaCreation.CreationData>(data => data.Property == "property")
+                .WhenHandling<SagaCreation.NoChangeMessage>();
+        }
+
+        [Test]
+        public void ExpectSagaDataShouldPassWhenCheckSucceeds()
+        {
+            Test.Saga<SagaCreation>(new SagaCreation.CreationData { Property = "property" })
+                .ExpectSagaData<SagaCreation.CreationData>(data => data.Property == "newData")
+                .WhenHandling<SagaCreation.ChangeMessage>();
+        }
+
+        [Test]
+        public void ExpectSagaDataShouldThrowExpectationExceptionWhenCheckDoesNotSucceed()
+        {
+            Assert.Throws<ExpectationException>(() => Test.Saga<SagaCreation>(new SagaCreation.CreationData { Property = "property" })
+                .ExpectSagaData<SagaCreation.CreationData>(data => data.Property == "42")
+                .WhenHandling<SagaCreation.ChangeMessage>());
+        }
+    }
+
+    public class SagaCreation : NServiceBus.Saga<SagaCreation.CreationData>,
+        IHandleMessages<SagaCreation.NoChangeMessage>,
+        IHandleMessages<SagaCreation.ChangeMessage>
+    {
+        public Task Handle(ChangeMessage message, IMessageHandlerContext context)
+        {
+            Data.Property = "newData";
+            return Task.FromResult(0);
+        }
+
+        public Task Handle(NoChangeMessage message, IMessageHandlerContext context)
+        {
+            return Task.FromResult(0);
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CreationData> mapper)
+        {
+        }
+
+        public class CreationData : IContainSagaData
+        {
+            public string Property { get; set; }
+            public Guid Id { get; set; }
+
+            public string Originator { get; set; }
+
+            public string OriginalMessageId { get; set; }
+        }
+
+        public class NoChangeMessage
+        {
+        }
+
+        public class ChangeMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Testing.Tests/Saga/SagaTimeoutTests.cs
+++ b/src/NServiceBus.Testing.Tests/Saga/SagaTimeoutTests.cs
@@ -38,7 +38,7 @@
         }
     }
 
-    public class TimeoutSaga : NServiceBus.Saga<TimeoutSaga.SingleTimeoutData>,
+    public class TimeoutSaga : NServiceBus.Saga<TimeoutSaga.TimeoutData>,
         IHandleMessages<TimeoutSaga.StartMessage>,
         IHandleTimeouts<TimeoutSaga.TimeoutMessage1>,
         IHandleTimeouts<TimeoutSaga.TimeoutMessage2>
@@ -59,11 +59,11 @@
             return context.Send(new SendMessage2());
         }
 
-        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SingleTimeoutData> mapper)
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutData> mapper)
         {
         }
 
-        public class SingleTimeoutData : IContainSagaData
+        public class TimeoutData : IContainSagaData
         {
             public Guid Id { get; set; }
 

--- a/src/NServiceBus.Testing.sln.DotSettings
+++ b/src/NServiceBus.Testing.sln.DotSettings
@@ -592,7 +592,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
-	
+		
 	
 	
 	

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectSagaData.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectSagaData.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus.Testing.ExpectedInvocations
+{
+    using System;
+
+    class ExpectSagaData<TSagaData> : ExpectInvocation where TSagaData : IContainSagaData
+    {
+        readonly Saga saga;
+        Func<TSagaData, bool> check;
+
+        public ExpectSagaData(Saga saga, Func<TSagaData, bool> check)
+        {
+            this.saga = saga;
+            this.check = check;
+        }
+
+        public override void Validate(TestableMessageHandlerContext context)
+        {
+            if (!check((TSagaData)saga.Entity))
+            {
+                Fail("Expected saga data to match but it does not.");
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Testing/NServiceBus.Testing.csproj
+++ b/src/NServiceBus.Testing/NServiceBus.Testing.csproj
@@ -85,6 +85,7 @@
     <Compile Include="ExpectedInvocations\ExpectSendToDestination.cs" />
     <Compile Include="ExpectedInvocations\ExpectReplyToOriginator.cs" />
     <Compile Include="ExpectedInvocations\ExpectDelayDeliveryWith.cs" />
+    <Compile Include="ExpectedInvocations\ExpectSagaData.cs" />
     <Compile Include="Handler.cs" />
     <Compile Include="ExpectedInvocations\ExpectInvocation.cs" />
     <Compile Include="InvokedMessageExtensions.cs" />

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -412,6 +412,15 @@
         }
 
         /// <summary>
+        /// Check that the saga data matches the given type and comlies with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectSagaData<TSagaData>(Func<TSagaData, bool> check) where TSagaData : IContainSagaData
+        {
+            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectSagaData<TSagaData>(saga, check));
+            return this;
+        }
+
+        /// <summary>
         /// Uses the given delegate to invoke the saga, checking all the expectations previously set up,
         /// and then clearing them for continued testing.
         /// </summary>

--- a/src/NServiceBus.Testing/Test.cs
+++ b/src/NServiceBus.Testing/Test.cs
@@ -28,23 +28,29 @@
         /// <summary>
         /// Begin the test script for a saga of type T while specifying the saga id.
         /// </summary>
-        public static Saga<T> Saga<T>(Guid sagaId) where T : Saga, new()
+        public static Saga<TSaga> Saga<TSaga>(Guid sagaId) where TSaga : Saga, new()
         {
-            var saga = (T) Activator.CreateInstance(typeof(T));
-
-            var prop = typeof(T).GetProperty("Data");
+            var prop = typeof(TSaga).GetProperty("Data");
+            IContainSagaData sagaData = null;
 
             if (prop != null)
             {
-                var sagaData = Activator.CreateInstance(prop.PropertyType) as IContainSagaData;
-
-                saga.Entity = sagaData;
-
-                if (saga.Entity != null)
-                {
-                    saga.Entity.Id = sagaId;
-                }
+                sagaData = Activator.CreateInstance(prop.PropertyType) as IContainSagaData;
+                sagaData.Id = sagaId;
             }
+
+            return Saga<TSaga>(sagaData);
+        }
+
+        /// <summary>
+        /// Begin the test script for a saga of type T with the passed in in <see cref="IContainSagaData" />.
+        /// </summary>
+        public static Saga<TSaga> Saga<TSaga>(IContainSagaData sagaData) where TSaga : Saga, new()
+        {
+            var saga = new TSaga
+            {
+                Entity = sagaData
+            };
 
             return Saga(saga);
         }


### PR DESCRIPTION
Allows the user to start a testing session providing a seed `IContainsSagaData`. For example:

```
Test.Saga<TestSaga>(new SagaData { Property = "property" })
```

It also includes the ability to "Expect" certain saga data 

```
Test.Saga<TestSaga>(new SagaData  { Property = "property" })
                .ExpectSagaData<SagaData >(data => data.Property == "property")
```

So the user can check their data is in a validate state after calling a handle method.

Connects to #29