### PR TITLE
Obsolete Test.Initialize

### DIFF
--- a/src/NServiceBus.Testing/Test.cs
+++ b/src/NServiceBus.Testing/Test.cs
@@ -83,6 +83,18 @@
             return messageCreator.CreateInstance(action);
         }
 
+        /// <summary>
+        /// Initializes the testing infrastructure.
+        /// </summary>
+        [ObsoleteEx(
+            Message = "Test initialization is no longer required and can be removed.",
+            RemoveInVersion = "7", 
+            TreatAsErrorFromVersion = "6")]
+        public static void Initialize(Action<EndpointConfiguration> customisations = null)
+        {
+            throw new NotImplementedException();
+        }
+
         static IMessageCreator messageCreator = new MessageMapper();
     }
 }


### PR DESCRIPTION
re-add `Test.Initialize` to add a proper obsolete message that tells users it's safe to just remove it. I think this is better than just removing it entirely.

@mat-mcloughlin @hmemcpy please review

Connects to #29