### PR TITLE
Default expectations

### DIFF
--- a/src/NServiceBus.Testing.Tests/HandlerTests.cs
+++ b/src/NServiceBus.Testing.Tests/HandlerTests.cs
@@ -125,10 +125,10 @@ namespace NServiceBus.Testing.Tests
         }
 
         [Test]
-        public void ShouldReplyWhenReceivingAMessage()
+        public void ShouldPassExpectReplyWhenReypling()
         {
             Test.Handler<ReplyingHandler>()
-                .ExpectReply<MyReply>(reply => reply != null)
+                .ExpectReply<MyReply>()
                 .OnMessage(new MyRequest { ShouldReply = true });
         }
 
@@ -154,10 +154,10 @@ namespace NServiceBus.Testing.Tests
         }
 
         [Test]
-        public void ShouldNotReplyWhenReceivingAWrongMessage()
+        public void ShouldPassExpectNotReplyWhenNotReplying()
         {
             Test.Handler<ReplyingHandler>()
-                .ExpectNotReply<MyReply>(reply => reply == null)
+                .ExpectNotReply<MyReply>()
                 .OnMessage(new MyRequest { ShouldReply = false });
         }
 
@@ -186,12 +186,28 @@ namespace NServiceBus.Testing.Tests
         public void ShouldPassExpectPublishWhenPublishing()
         {
             Test.Handler<PublishingHandler<Publish1>>()
+                .ExpectPublish<Publish1>()
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldPassExpectPublishWhenPublishingWithCustomCheck()
+        {
+            Test.Handler<PublishingHandler<Publish1>>()
                 .ExpectPublish<Publish1>(m => true)
                 .OnMessage<TestMessage>();
         }
 
         [Test]
         public void ShouldFailExpectNotPublishWhenPublishing()
+        {
+            Assert.Throws<ExpectationException>(() => Test.Handler<PublishingHandler<Publish1>>()
+                .ExpectNotPublish<Publish1>()
+                .OnMessage<TestMessage>());
+        }
+
+        [Test]
+        public void ShouldFailExpectNotPublishWithCheckWhenPublishing()
         {
             Assert.Throws<ExpectationException>(() => Test.Handler<PublishingHandler<Publish1>>()
                 .ExpectNotPublish<Publish1>(m => true)
@@ -281,6 +297,14 @@ namespace NServiceBus.Testing.Tests
         public void ShouldPassExpectNotPublishIfNotPublishing()
         {
             Test.Handler<EmptyHandler>()
+                .ExpectNotPublish<Publish1>()
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldPassExpectNotPublishWithCheckIfNotPublishing()
+        {
+            Test.Handler<EmptyHandler>()
                 .ExpectNotPublish<Publish1>(m => true)
                 .OnMessage<TestMessage>();
         }
@@ -307,12 +331,28 @@ namespace NServiceBus.Testing.Tests
         public void ShouldPassExpectSendIfSending()
         {
             Test.Handler<SendingHandler<Send1>>()
+                .ExpectSend<Send1>()
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldPassExpectSendWithCheckIfSending()
+        {
+            Test.Handler<SendingHandler<Send1>>()
                 .ExpectSend<Send1>(m => true)
                 .OnMessage<TestMessage>();
         }
 
         [Test]
         public void ShouldFailExpectSendIfNotSending()
+        {
+            Assert.Throws<ExpectationException>(() => Test.Handler<EmptyHandler>()
+                .ExpectSend<Send1>()
+                .OnMessage<TestMessage>());
+        }
+
+        [Test]
+        public void ShouldFailExpectSendWithCheckIfNotSending()
         {
             Assert.Throws<ExpectationException>(() => Test.Handler<EmptyHandler>()
                 .ExpectSend<Send1>(m => true)
@@ -349,12 +389,28 @@ namespace NServiceBus.Testing.Tests
         public void ShouldPassExpectNotSendIfNotSending()
         {
             Test.Handler<EmptyHandler>()
+                .ExpectNotSend<Send1>()
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldPassExpectNotSendWithCheckIfNotSending()
+        {
+            Test.Handler<EmptyHandler>()
                 .ExpectNotSend<Send1>(m => true)
                 .OnMessage<TestMessage>();
         }
 
         [Test]
         public void ShouldFailExpectNotSendIfSending()
+        {
+            Assert.Throws<ExpectationException>(() => Test.Handler<SendingHandler<Send1>>()
+                .ExpectNotSend<Send1>()
+                .OnMessage<TestMessage>());
+        }
+
+        [Test]
+        public void ShouldFailExpectNotSendWithCheckIfSending()
         {
             Assert.Throws<ExpectationException>(() => Test.Handler<SendingHandler<Send1>>()
                 .ExpectNotSend<Send1>(m => true)
@@ -383,12 +439,28 @@ namespace NServiceBus.Testing.Tests
         public void ShouldFailExpectSendLocalIfNotSendingLocal()
         {
             Assert.Throws<ExpectationException>(() => Test.Handler<SendingHandler<Send1>>()
+                .ExpectSendLocal<Send1>()
+                .OnMessage<TestMessage>());
+        }
+
+        [Test]
+        public void ShouldFailExpectSendLocalWithCheckIfNotSendingLocal()
+        {
+            Assert.Throws<ExpectationException>(() => Test.Handler<SendingHandler<Send1>>()
                 .ExpectSendLocal<Send1>(m => true)
                 .OnMessage<TestMessage>());
         }
 
         [Test]
         public void ShouldPassExpectSendLocalIfSendingLocal()
+        {
+            Test.Handler<SendingLocalHandler<Send1>>()
+                .ExpectSendLocal<Send1>()
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldPassExpectSendLocalWithCheckIfSendingLocal()
         {
             Test.Handler<SendingLocalHandler<Send1>>()
                 .ExpectSendLocal<Send1>(m => true)
@@ -526,6 +598,14 @@ namespace NServiceBus.Testing.Tests
         public void ShouldFailExpectForwardCurrentMessageToIfMessageNotForwarded()
         {
             Assert.Throws<ExpectationException>(() => Test.Handler<NotForwardingMessageHandler>()
+                .ExpectForwardCurrentMessageTo()
+                .OnMessage<TestMessage>());
+        }
+
+        [Test]
+        public void ShouldFailExpectForwardCurrentMessageWithCheckToIfMessageNotForwarded()
+        {
+            Assert.Throws<ExpectationException>(() => Test.Handler<NotForwardingMessageHandler>()
                 .ExpectForwardCurrentMessageTo(dest => true)
                 .OnMessage<TestMessage>());
         }
@@ -538,6 +618,16 @@ namespace NServiceBus.Testing.Tests
             Assert.Throws<ExpectationException>(() => Test.Handler(handler)
                 .ExpectForwardCurrentMessageTo(dest => dest == "expectedDestination")
                 .OnMessage<TestMessage>());
+        }
+
+        [Test]
+        public void ShouldPassExpectForwardCurrentMessageToIfMessageForwarded()
+        {
+            var handler = new ForwardingMessageHandler("somewhere");
+
+            Test.Handler(handler)
+                .ExpectForwardCurrentMessageTo()
+                .OnMessage<TestMessage>();
         }
 
         [Test]
@@ -555,8 +645,26 @@ namespace NServiceBus.Testing.Tests
         public void ShouldPassExpectNotForwardCurrentMessageToIfMessageNotForwarded()
         {
             Test.Handler<NotForwardingMessageHandler>()
+                .ExpectNotForwardCurrentMessageTo()
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldPassExpectNotForwardCurrentMessageToWithCheckIfMessageNotForwarded()
+        {
+            Test.Handler<NotForwardingMessageHandler>()
                 .ExpectNotForwardCurrentMessageTo(dest => true)
                 .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldFailExpectNotForwardCurrentMessageToIfMessageForwardedToAnyDestination()
+        {
+            var handler = new ForwardingMessageHandler("somewhere");
+
+            Assert.Throws<ExpectationException>(() => Test.Handler(handler)
+                .ExpectNotForwardCurrentMessageTo()
+                .OnMessage<TestMessage>());
         }
 
         [Test]

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectDelayDeliveryWith.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectDelayDeliveryWith.cs
@@ -5,7 +5,7 @@
 
     class ExpectDelayDeliveryWith<TMessage> : ExpectInvocation
     {
-        public ExpectDelayDeliveryWith(Func<TMessage, TimeSpan, bool> check)
+        public ExpectDelayDeliveryWith(Func<TMessage, TimeSpan, bool> check = null)
         {
             this.check = check ?? ((m, t) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectDoNotDeliverBefore.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectDoNotDeliverBefore.cs
@@ -5,9 +5,9 @@
 
     class ExpectNotDoNotDeliverBefore<TMessage> : ExpectInvocation
     {
-        public ExpectNotDoNotDeliverBefore(Func<TMessage, DateTime, bool> check)
+        public ExpectNotDoNotDeliverBefore(Func<TMessage, DateTime, bool> check = null)
         {
-            this.check = check;
+            this.check = check ?? ((m, d) => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectForwardCurrentMessageTo.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectForwardCurrentMessageTo.cs
@@ -6,9 +6,9 @@
 
     class ExpectForwardCurrentMessageTo : ExpectInvocation
     {
-        public ExpectForwardCurrentMessageTo(Func<string, bool> check)
+        public ExpectForwardCurrentMessageTo(Func<string, bool> check = null)
         {
-            this.check = check;
+            this.check = check ?? (s => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDelayDeliveryWith.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDelayDeliveryWith.cs
@@ -5,7 +5,7 @@
 
     class ExpectNotDelayDeliveryWith<TMessage> : ExpectInvocation
     {
-        public ExpectNotDelayDeliveryWith(Func<TMessage, TimeSpan, bool> check)
+        public ExpectNotDelayDeliveryWith(Func<TMessage, TimeSpan, bool> check = null)
         {
             this.check = check ?? ((m, t) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDoNotDeliverBefore.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDoNotDeliverBefore.cs
@@ -5,9 +5,9 @@
 
     class ExpectDoNotDeliverBefore<TMessage> : ExpectInvocation
     {
-        public ExpectDoNotDeliverBefore(Func<TMessage, DateTime, bool> check)
+        public ExpectDoNotDeliverBefore(Func<TMessage, DateTime, bool> check = null)
         {
-            this.check = check;
+            this.check = check ?? ((m, d) => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotForwardCurrentMessageTo.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotForwardCurrentMessageTo.cs
@@ -6,9 +6,9 @@
 
     class ExpectNotForwardCurrentMessageTo : ExpectInvocation
     {
-        public ExpectNotForwardCurrentMessageTo(Func<string, bool> check)
+        public ExpectNotForwardCurrentMessageTo(Func<string, bool> check = null)
         {
-            this.check = check;
+            this.check = check ?? (s => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotPublish.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotPublish.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectNotPublish<TMessage> : ExpectInvocation
     {
-        public ExpectNotPublish(Func<TMessage, PublishOptions, bool> check)
+        public ExpectNotPublish(Func<TMessage, PublishOptions, bool> check = null)
         {
             this.check = check ?? ((message, options) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotReply.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotReply.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectNotReply<TMessage> : ExpectInvocation
     {
-        public ExpectNotReply(Func<TMessage, ReplyOptions, bool> check)
+        public ExpectNotReply(Func<TMessage, ReplyOptions, bool> check = null)
         {
             this.check = check ?? ((message, options) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotSend.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotSend.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectNotSend<TMessage> : ExpectInvocation
     {
-        public ExpectNotSend(Func<TMessage, SendOptions, bool> check)
+        public ExpectNotSend(Func<TMessage, SendOptions, bool> check = null)
         {
             this.check = check ?? ((message, options) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotSendLocal.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotSendLocal.cs
@@ -5,9 +5,9 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectNotSendLocal<TMessage> : ExpectInvocation
     {
-        public ExpectNotSendLocal(Func<TMessage, bool> check)
+        public ExpectNotSendLocal(Func<TMessage, bool> check = null)
         {
-            this.check = check;
+            this.check = check ?? (x => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectPublish.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectPublish.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectPublish<TMessage> : ExpectInvocation
     {
-        public ExpectPublish(Func<TMessage, PublishOptions, bool> check)
+        public ExpectPublish(Func<TMessage, PublishOptions, bool> check = null)
         {
             this.check = check ?? ((message, options) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectReply.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectReply.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectReply<TMessage> : ExpectInvocation
     {
-        public ExpectReply(Func<TMessage, ReplyOptions, bool> check)
+        public ExpectReply(Func<TMessage, ReplyOptions, bool> check = null)
         {
             this.check = check ?? ((message, options) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectSend.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectSend.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectSend<TMessage> : ExpectInvocation
     {
-        public ExpectSend(Func<TMessage, SendOptions, bool> check)
+        public ExpectSend(Func<TMessage, SendOptions, bool> check = null)
         {
             this.check = check ?? ((message, options) => true);
         }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectSendLocal.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectSendLocal.cs
@@ -5,9 +5,9 @@ namespace NServiceBus.Testing.ExpectedInvocations
 
     class ExpectSendLocal<TMessage> : ExpectInvocation
     {
-        public ExpectSendLocal(Func<TMessage, bool> check)
+        public ExpectSendLocal(Func<TMessage, bool> check = null)
         {
-            this.check = check;
+            this.check = check ?? (x => true);
         }
 
         public override void Validate(TestableMessageHandlerContext context)

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectSendToDestination.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectSendToDestination.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.Testing.ExpectedInvocations
     {
         readonly Func<TMessage, string, bool> check;
 
-        public ExpectSendToDestination(Func<TMessage, string, bool> check)
+        public ExpectSendToDestination(Func<TMessage, string, bool> check = null)
         {
             this.check = check ?? ((m, s) => true);
         }

--- a/src/NServiceBus.Testing/Handler.cs
+++ b/src/NServiceBus.Testing/Handler.cs
@@ -46,7 +46,7 @@
         /// <summary>
         /// Check that the handler sends a message of the given type complying with the given predicate.
         /// </summary>
-        public Handler<T> ExpectSend<TMessage>(Func<TMessage, SendOptions, bool> check)
+        public Handler<T> ExpectSend<TMessage>(Func<TMessage, SendOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectSend<TMessage>(check));
             return this;
@@ -63,7 +63,7 @@
         /// <summary>
         /// Check that the handler does not send a message of the given type complying with the given predicate.
         /// </summary>
-        public Handler<T> ExpectNotSend<TMessage>(Func<TMessage, SendOptions, bool> check)
+        public Handler<T> ExpectNotSend<TMessage>(Func<TMessage, SendOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotSend<TMessage>(check));
             return this;
@@ -80,7 +80,7 @@
         /// <summary>
         /// Check that the handler does not reply with a given message
         /// </summary>
-        public Handler<T> ExpectNotReply<TMessage>(Func<TMessage, ReplyOptions, bool> check)
+        public Handler<T> ExpectNotReply<TMessage>(Func<TMessage, ReplyOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotReply<TMessage>(check));
             return this;
@@ -97,7 +97,7 @@
         /// <summary>
         /// Check that the handler replies with the given message type complying with the given predicate.
         /// </summary>
-        public Handler<T> ExpectReply<TMessage>(Func<TMessage, ReplyOptions, bool> check)
+        public Handler<T> ExpectReply<TMessage>(Func<TMessage, ReplyOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectReply<TMessage>(check));
             return this;
@@ -115,7 +115,7 @@
         /// Check that the handler sends the given message type to its local queue
         /// and that the message complies with the given predicate.
         /// </summary>
-        public Handler<T> ExpectSendLocal<TMessage>(Func<TMessage, bool> check)
+        public Handler<T> ExpectSendLocal<TMessage>(Func<TMessage, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectSendLocal<TMessage>(check));
             return this;
@@ -124,7 +124,7 @@
         /// <summary>
         /// Check that the handler does not send a message type to its local queue that complies with the given predicate.
         /// </summary>
-        public Handler<T> ExpectNotSendLocal<TMessage>(Func<TMessage, bool> check)
+        public Handler<T> ExpectNotSendLocal<TMessage>(Func<TMessage, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotSendLocal<TMessage>(check));
             return this;
@@ -133,7 +133,7 @@
         /// <summary>
         /// Check that the handler publishes a message of the given type complying with the given predicate.
         /// </summary>
-        public Handler<T> ExpectPublish<TMessage>(Func<TMessage, PublishOptions, bool> check)
+        public Handler<T> ExpectPublish<TMessage>(Func<TMessage, PublishOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectPublish<TMessage>(check));
             return this;
@@ -150,7 +150,7 @@
         /// <summary>
         /// Check that the handler does not publish any messages of the given type complying with the given predicate.
         /// </summary>
-        public Handler<T> ExpectNotPublish<TMessage>(Func<TMessage, PublishOptions, bool> check)
+        public Handler<T> ExpectNotPublish<TMessage>(Func<TMessage, PublishOptions, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotPublish<TMessage>(check));
             return this;
@@ -221,7 +221,7 @@
         /// <summary>
         /// Check that the handler doesn't forward a message to the given destination.
         /// </summary>
-        public Handler<T> ExpectNotForwardCurrentMessageTo(Func<string, bool> check)
+        public Handler<T> ExpectNotForwardCurrentMessageTo(Func<string, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotForwardCurrentMessageTo(check));
             return this;
@@ -230,7 +230,7 @@
         /// <summary>
         /// Check that the handler forwards a message to the given destination.
         /// </summary>
-        public Handler<T> ExpectForwardCurrentMessageTo(Func<string, bool> check)
+        public Handler<T> ExpectForwardCurrentMessageTo(Func<string, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectForwardCurrentMessageTo(check));
             return this;

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -132,6 +132,23 @@
         }
 
         /// <summary>
+        /// Check that the saga does not reply with the given message type complying with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectNotReply<TMessage>(Func<TMessage, ReplyOptions, bool> check = null)
+        {
+            testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotReply<TMessage>(check));
+            return this;
+        }
+
+        /// <summary>
+        /// Check that the saga does not reply with the given message type complying with the given predicate.
+        /// </summary>
+        public Saga<T> ExpectNotReply<TMessage>(Func<TMessage, bool> check)
+        {
+            return ExpectNotReply((TMessage m, ReplyOptions _) => check(m));
+        }
+
+        /// <summary>
         /// Check that the saga doesn't forward a message to the given destination.
         /// </summary>
         public Saga<T> ExpectNotForwardCurrentMessageTo(Func<string, bool> check = null)

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -134,7 +134,7 @@
         /// <summary>
         /// Check that the saga doesn't forward a message to the given destination.
         /// </summary>
-        public Saga<T> ExpectNotForwardCurrentMessageTo(Func<string, bool> check)
+        public Saga<T> ExpectNotForwardCurrentMessageTo(Func<string, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectNotForwardCurrentMessageTo(check));
             return this;
@@ -143,7 +143,7 @@
         /// <summary>
         /// Check that the saga forwards a message to the given destination.
         /// </summary>
-        public Saga<T> ExpectForwardCurrentMessageTo(Func<string, bool> check)
+        public Saga<T> ExpectForwardCurrentMessageTo(Func<string, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectForwardCurrentMessageTo(check));
             return this;
@@ -396,7 +396,7 @@
         /// <summary>
         /// Check that the saga sends the given message type to the appropriate destination.
         /// </summary>
-        public Saga<T> ExpectSendToDestination<TMessage>(Func<TMessage, string, bool> check)
+        public Saga<T> ExpectSendToDestination<TMessage>(Func<TMessage, string, bool> check = null)
         {
             testableMessageHandlerContext.ExpectedInvocations.Add(new ExpectSendToDestination<TMessage>(check));
             return this;


### PR DESCRIPTION
* Makes most `check` parameters for `ExpectXYZ` expectations optional, defaulting them to `x => true`.
* Also adds ExpectNotReply for sagas.

related to #7 
related to #5

@Particular/nservicebus-maintainers @mat-mcloughlin @hmemcpy please review