### PR TITLE
add extension method for easier handler invocation

### DIFF
--- a/src/NServiceBus.Testing/Fakes/MessageHandlerExtensions.cs
+++ b/src/NServiceBus.Testing/Fakes/MessageHandlerExtensions.cs
@@ -1,0 +1,37 @@
+﻿namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using NServiceBus.Testing;
+
+    /// <summary>
+    /// Extension methods for message handlers.
+    /// </summary>
+    public static class MessageHandlerExtensions
+    {
+        /// <summary>
+        /// Invokes the handler method with the given message and a new <see cref="TestableMessageHandlerContext" />.
+        /// </summary>
+        /// <param name="handler">The handler to invoke.</param>
+        /// <param name="message">The message to pass to the handler.</param>
+        /// <returns>The created <see cref="TestableMessageHandlerContext" /> which was passed to the handler.</returns>
+        public static async Task<TestableMessageHandlerContext> Handle<T>(this IHandleMessages<T> handler, T message)
+        {
+            var context = new TestableMessageHandlerContext();
+            await handler.Handle(message, context);
+            return context;
+        }
+
+        /// <summary>
+        /// Invokes the saga method with the given message and a new <see cref="TestableMessageHandlerContext" />.
+        /// </summary>
+        /// <param name="saga">The saga to invoke.</param>
+        /// <param name="message">The message to pass to the saga.</param>
+        /// <returns>The created <see cref="TestableMessageHandlerContext" /> which was passed to the saga.</returns>
+        public static async Task<TestableMessageHandlerContext> Handle<T>(this IAmStartedByMessages<T> saga, T message)
+        {
+            var context = new TestableMessageHandlerContext();
+            await saga.Handle(message, context);
+            return context;
+        }
+    }
+}

--- a/src/NServiceBus.Testing/NServiceBus.Testing.csproj
+++ b/src/NServiceBus.Testing/NServiceBus.Testing.csproj
@@ -88,6 +88,8 @@
     <Compile Include="ExpectedInvocations\ExpectSagaData.cs" />
     <Compile Include="Handler.cs" />
     <Compile Include="ExpectedInvocations\ExpectInvocation.cs" />
+    <Compile Include="Fakes\OutgoingMessageExtensions.cs" />
+    <Compile Include="Fakes\MessageHandlerExtensions.cs" />
     <Compile Include="Saga.cs" />
     <Compile Include="Test.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
adding two simple extension methods.

without extension:

```
var context = new TestableMessageHandlerContext();

await handler.Handle(new MyMessage(), context);

Assert...
```

with extension:

```
var context = await handler.Handle(new MyMessage());

Assert...
```

Connects to https://github.com/Particular/NServiceBus.Testing/issues/29