### PR TITLE
Allow configuring the context

### DIFF
--- a/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
+++ b/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
@@ -95,6 +95,7 @@ namespace NServiceBus.Testing
         where T : NServiceBus.Saga
     {
         public NServiceBus.Testing.Saga<T> AssertSagaCompletionIs(bool complete) { }
+        public NServiceBus.Testing.Saga<T> ConfigureHandlerContext(System.Action<NServiceBus.Testing.TestableMessageHandlerContext> contextInitializer) { }
         public NServiceBus.Testing.Saga<T> ExpectForwardCurrentMessageTo(System.Func<string, bool> check = null) { }
         public NServiceBus.Testing.Saga<T> ExpectHandleCurrentMessageLater() { }
         public NServiceBus.Testing.Saga<T> ExpectNotForwardCurrentMessageTo(System.Func<string, bool> check = null) { }

--- a/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
+++ b/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
@@ -27,6 +27,7 @@ namespace NServiceBus.Testing
     }
     public class Handler<T>
     {
+        public NServiceBus.Testing.Handler<T> ConfigureHandlerContext(System.Action<NServiceBus.Testing.TestableMessageHandlerContext> contextInitializer) { }
         public NServiceBus.Testing.Handler<T> ExpectDefer<TMessage>(System.Func<TMessage, System.TimeSpan, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectDefer<TMessage>(System.Func<TMessage, System.DateTime, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectDoNotContinueDispatchingCurrentMessageToHandlers() { }
@@ -56,10 +57,10 @@ namespace NServiceBus.Testing
         public NServiceBus.Testing.Handler<T> ExpectSendToDestination<TMessage>(System.Func<TMessage, string, bool> check) { }
         [System.ObsoleteAttribute(@"ExpectSendToSites is no longer supported by the NServiceBus Testing Framework. You can access the configured sites on the SendOptions by calling 'GetSitesRoutingTo()'. Check the documentation to find out more about writing Unit Tests without the Testing Framework in NServiceBus 6. Will be removed in version 7.0.0.", true)]
         public NServiceBus.Testing.Handler<T> ExpectSendToSites<TMessage>(System.Func<TMessage, System.Collections.Generic.IEnumerable<string>, bool> check) { }
-        public void OnMessage<TMessage>(System.Action<TMessage> initializeMessage = null) { }
         public void OnMessage<TMessage>(string messageId, System.Action<TMessage> initializeMessage = null) { }
-        public void OnMessage<TMessage>(TMessage initializedMessage) { }
+        public void OnMessage<TMessage>(System.Action<TMessage> initializeMessage = null) { }
         public void OnMessage<TMessage>(TMessage message, string messageId) { }
+        public void OnMessage<TMessage>(TMessage initializedMessage) { }
         public NServiceBus.Testing.Handler<T> SetIncomingHeader(string key, string value) { }
         public NServiceBus.Testing.Handler<T> WithExternalDependencies(System.Action<T> actionToSetUpExternalDependencies) { }
     }

--- a/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
+++ b/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
@@ -132,7 +132,8 @@ namespace NServiceBus.Testing
         public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetIn<TMessage>(System.Func<TMessage, System.TimeSpan, bool> check = null) { }
         public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetIn<TMessage>(System.Action<TMessage, System.TimeSpan> check) { }
         public NServiceBus.Testing.Saga<T> SetIncomingHeader(string key, string value) { }
-        [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute("Set the message ID on the context by using ConfigureHandlerContext. Will be remov" +
+            "ed in version 7.0.0.", true)]
         public NServiceBus.Testing.Saga<T> SetMessageId(string messageId) { }
         public NServiceBus.Testing.Saga<T> When(System.Func<T, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task> sagaIsInvoked) { }
         public NServiceBus.Testing.Saga<T> When<TMessage>(System.Func<T, System.Func<TMessage, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task>> handlerSelector, TMessage message) { }

--- a/src/NServiceBus.Testing.Tests/Saga/SagaTests.cs
+++ b/src/NServiceBus.Testing.Tests/Saga/SagaTests.cs
@@ -68,6 +68,34 @@
             Assert.IsTrue(containsCustomHeader);
             Assert.AreEqual(expectedHeaderValue, receivedHeaderValue);
         }
+
+        [Test]
+        public void ConfigureHandlerContext()
+        {
+            var messageId = Guid.NewGuid().ToString();
+            var replyToAddress = "0118 999 881 999 119 725 3";
+            TestableMessageHandlerContext configuredContextInstance = null;
+            IMessageHandlerContext receivedContextInstance = null;
+
+            Test.Saga<CustomSaga<MyRequest, MySagaData>>()
+                .WithExternalDependencies(s =>
+                    s.HandlerAction = (request, context, data) =>
+                    {
+                        receivedContextInstance = context;
+                        return Task.FromResult(0);
+                    })
+                .ConfigureHandlerContext(c =>
+                {
+                    c.MessageId = messageId;
+                    c.ReplyToAddress = replyToAddress;
+                    configuredContextInstance = c;
+                })
+                .When<MyRequest>(s => s.Handle);
+
+            Assert.AreEqual(messageId, receivedContextInstance.MessageId);
+            Assert.AreEqual(replyToAddress, receivedContextInstance.ReplyToAddress);
+            Assert.AreSame(receivedContextInstance, configuredContextInstance);
+        }
     }
 
     public class MyRequest

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -505,7 +505,8 @@
         /// </summary>
         [ObsoleteEx(
             RemoveInVersion = "7",
-            TreatAsErrorFromVersion = "6")]
+            TreatAsErrorFromVersion = "6",
+            Message = "Set the message ID on the context by using ConfigureHandlerContext")]
         public Saga<T> SetMessageId(string messageId)
         {
             throw new NotImplementedException();

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -51,6 +51,15 @@
         }
 
         /// <summary>
+        /// Provides a way to customize the <see cref="IMessageHandlerContext" /> instance received by the message handler.
+        /// </summary>
+        public Saga<T> ConfigureHandlerContext(Action<TestableMessageHandlerContext> contextInitializer)
+        {
+            contextInitializer(testContext);
+            return this;
+        }
+
+        /// <summary>
         /// Set the headers on an incoming message that will be return
         /// when code calls Bus.CurrentMessageContext.Headers
         /// </summary>


### PR DESCRIPTION
Allows Handler and Saga tests to configure the MessageHandlerContext which will be received by the handle method by using `ConfigureHandlerContext` before calling `OnMessage` or `When`.

This is required in case users want to setup properties on the context which can't be set by a provided extension method or parameter.

@Particular/nservicebus-maintainers @WojcikMike @mat-mcloughlin please review