### PR TITLE
Improve obsolete messages and implement ExpectSendToDestination

### DIFF
--- a/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
+++ b/src/NServiceBus.Testing.Tests/API/APIApprovals.ApproveTesting.approved.txt
@@ -42,20 +42,19 @@ namespace NServiceBus.Testing
         public NServiceBus.Testing.Handler<T> ExpectNotSend<TMessage>(System.Func<TMessage, NServiceBus.SendOptions, bool> check = null) { }
         public NServiceBus.Testing.Handler<T> ExpectNotSend<TMessage>(System.Func<TMessage, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectNotSendLocal<TMessage>(System.Func<TMessage, bool> check = null) { }
-        [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute(@"ExpectNotSendToSites is no longer supported by the NServiceBus Testing Framework. You can access the configured sites on the SendOptions by calling 'GetSitesRoutingTo()'. Check the documentation to find out more about writing Unit Tests without the Testing Framework in NServiceBus 6. Will be removed in version 7.0.0.", true)]
         public NServiceBus.Testing.Handler<T> ExpectNotSendToSites<TMessage>(System.Func<TMessage, System.Collections.Generic.IEnumerable<string>, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectPublish<TMessage>(System.Func<TMessage, NServiceBus.PublishOptions, bool> check = null) { }
         public NServiceBus.Testing.Handler<T> ExpectPublish<TMessage>(System.Func<TMessage, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectReply<TMessage>(System.Func<TMessage, NServiceBus.ReplyOptions, bool> check = null) { }
         public NServiceBus.Testing.Handler<T> ExpectReply<TMessage>(System.Func<TMessage, bool> check) { }
-        [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute("Please use `ExpectReply` instead. Will be removed in version 7.0.0.", true)]
         public NServiceBus.Testing.Handler<T> ExpectReturn<TEnum>(System.Func<TEnum, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectSend<TMessage>(System.Func<TMessage, NServiceBus.SendOptions, bool> check = null) { }
         public NServiceBus.Testing.Handler<T> ExpectSend<TMessage>(System.Func<TMessage, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectSendLocal<TMessage>(System.Func<TMessage, bool> check = null) { }
-        [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
         public NServiceBus.Testing.Handler<T> ExpectSendToDestination<TMessage>(System.Func<TMessage, string, bool> check) { }
-        [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute(@"ExpectSendToSites is no longer supported by the NServiceBus Testing Framework. You can access the configured sites on the SendOptions by calling 'GetSitesRoutingTo()'. Check the documentation to find out more about writing Unit Tests without the Testing Framework in NServiceBus 6. Will be removed in version 7.0.0.", true)]
         public NServiceBus.Testing.Handler<T> ExpectSendToSites<TMessage>(System.Func<TMessage, System.Collections.Generic.IEnumerable<string>, bool> check) { }
         public void OnMessage<TMessage>(System.Action<TMessage> initializeMessage = null) { }
         public void OnMessage<TMessage>(string messageId, System.Action<TMessage> initializeMessage = null) { }

--- a/src/NServiceBus.Testing.Tests/Handler/ExpectSendToDestinationTests.cs
+++ b/src/NServiceBus.Testing.Tests/Handler/ExpectSendToDestinationTests.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.Testing.Tests.Handler
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ExpectSendToDestinationTests
+    {
+        [Test]
+        public void ShouldPassWhenDestinationMatches()
+        {
+            var expectedDestination = "expected destination";
+
+            Test.Handler<SendingHandler<Send1>>()
+                .WithExternalDependencies(h => h.OptionsProvider = () =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(expectedDestination);
+                    return options;
+                })
+                .ExpectSendToDestination<Send1>((message, destination) => destination == expectedDestination)
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldNotPassWhenDestinationDoesNotMatch()
+        {
+            Assert.Throws<ExpectationException>(() => Test.Handler<SendingHandler<TestMessage>>()
+                .WithExternalDependencies(h => h.OptionsProvider = () =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination("somewhere");
+                    return options;
+                })
+                .ExpectSendToDestination<Send1>((message, destination) => destination == "anywhere")
+                .OnMessage<TestMessage>());
+        }
+
+        class SendingHandler<TSend> : IHandleMessages<TestMessage> where TSend : IMessage
+        {
+            public Action<TSend> ModifyMessage { get; set; } = m => { };
+
+            public Func<SendOptions> OptionsProvider { get; set; } = () => new SendOptions();
+
+            public Task Handle(TestMessage message, IMessageHandlerContext context)
+            {
+                return context.Send(ModifyMessage, OptionsProvider());
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Testing.Tests/NServiceBus.Testing.Tests.csproj
+++ b/src/NServiceBus.Testing.Tests/NServiceBus.Testing.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Handler\ExpectReplyTests.cs" />
     <Compile Include="Handler\ExpectHandleCurrentMessageLaterTests.cs" />
     <Compile Include="Handler\ExpectSendTests.cs" />
+    <Compile Include="Handler\ExpectSendToDestinationTests.cs" />
     <Compile Include="Saga\ExpectForwardCurrentMessageToTests.cs" />
     <Compile Include="Saga\SagaTests.cs" />
     <Compile Include="Handler\HandlerTests.cs" />

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectSendToDestination.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectSendToDestination.cs
@@ -21,7 +21,7 @@ namespace NServiceBus.Testing
 
             if (!sentMessages.Any(i => check(i.Message, i.Options.GetDestination())))
             {
-                Fail($"Expected a message of type {typeof(TMessage).Name} to be sent to a specific destination but a message matching your constraints was found.");
+                Fail($"Expected a message of type {typeof(TMessage).Name} to be sent to a specific destination but a message matching your constraints was not found.");
             }
         }
     }

--- a/src/NServiceBus.Testing/Handler.cs
+++ b/src/NServiceBus.Testing/Handler.cs
@@ -233,6 +233,15 @@
         }
 
         /// <summary>
+        /// Check that the handler sends the given message type to the appropriate destination.
+        /// </summary>
+        public Handler<T> ExpectSendToDestination<TMessage>(Func<TMessage, string, bool> check)
+        {
+            testableMessageHandlerContext.AddExpectation(new ExpectSendToDestination<TMessage>(check));
+            return this;
+        }
+
+        /// <summary>
         /// Activates the test that has been set up passing in the given message.
         /// </summary>
         public void OnMessage<TMessage>(Action<TMessage> initializeMessage = null)
@@ -288,19 +297,9 @@
         /// </summary>
         [ObsoleteEx(
             RemoveInVersion = "7",
-            TreatAsErrorFromVersion = "6")]
+            TreatAsErrorFromVersion = "6",
+            ReplacementTypeOrMember = "ExpectReply")]
         public Handler<T> ExpectReturn<TEnum>(Func<TEnum, bool> check)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Check that the handler sends the given message type to the appropriate destination.
-        /// </summary>
-        [ObsoleteEx(
-            RemoveInVersion = "7",
-            TreatAsErrorFromVersion = "6")]
-        public Handler<T> ExpectSendToDestination<TMessage>(Func<TMessage, string, bool> check)
         {
             throw new NotImplementedException();
         }
@@ -310,7 +309,8 @@
         /// </summary>
         [ObsoleteEx(
             RemoveInVersion = "7",
-            TreatAsErrorFromVersion = "6")]
+            TreatAsErrorFromVersion = "6",
+            Message = "ExpectSendToSites is no longer supported by the NServiceBus Testing Framework. You can access the configured sites on the SendOptions by calling 'GetSitesRoutingTo()'. Check the documentation to find out more about writing Unit Tests without the Testing Framework in NServiceBus 6.")]
         public Handler<T> ExpectSendToSites<TMessage>(Func<TMessage, IEnumerable<string>, bool> check)
         {
             throw new NotImplementedException();
@@ -321,7 +321,8 @@
         /// </summary>
         [ObsoleteEx(
             RemoveInVersion = "7",
-            TreatAsErrorFromVersion = "6")]
+            TreatAsErrorFromVersion = "6",
+            Message = "ExpectNotSendToSites is no longer supported by the NServiceBus Testing Framework. You can access the configured sites on the SendOptions by calling 'GetSitesRoutingTo()'. Check the documentation to find out more about writing Unit Tests without the Testing Framework in NServiceBus 6.")]
         public Handler<T> ExpectNotSendToSites<TMessage>(Func<TMessage, IEnumerable<string>, bool> check)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
* Improved messages for obsoleted methods
* Removed obsolete attribute from `ExpectSendToDestination` again. This was still supported on the saga and the expectation already implemented. Not sure why this was obsoleted on the handler. Maybe @hmemcpy remembers? (+added a test for it)

@Particular/nservicebus-maintainers @mat-mcloughlin @WojcikMike please have a look