### PR TITLE
Better guidance when WhenSagaTimesOut is used without previous RequestTimeout

### DIFF
--- a/src/NServiceBus.Testing.Tests/Timeouts.cs
+++ b/src/NServiceBus.Testing.Tests/Timeouts.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Testing.Tests
 {
     using System;
+    using System.Collections.Generic;
     using NUnit.Framework;
     using Saga;
 
@@ -37,6 +38,17 @@
             Test.Saga<TimeoutSaga>()
                 .ExpectTimeoutToBeSetIn<MyTimeout>((state, expiresIn) => state.SomeProperty == "Test")
                 .When(saga => saga.Handle(new StartMessage()));
+        }
+
+        [Test]
+        public void WhenSagasTimesOut_is_invoked_without_previous_when_should_throw_meaningful_exception()
+        {
+            Assert.That(() =>
+                Test.Saga<TimeoutSaga>()
+                    .ExpectTimeoutToBeSetIn<MyTimeout>((state, expiresIn) => expiresIn == TimeSpan.FromDays(1))
+                    .WhenSagaTimesOut()
+                    .AssertSagaCompletionIs(false)
+            , Throws.Exception.TypeOf<Exception>().With.Message.StartsWith("Unable to find a matching timeout state.").And.Not.TypeOf<KeyNotFoundException>());
         }
     }
 

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -240,7 +240,7 @@ namespace NServiceBus.Testing
                 );
             return this;
         }
-        
+
         /// <summary>
         /// Check that the saga replies to the originator with the given message type.
         /// </summary>
@@ -362,9 +362,14 @@ namespace NServiceBus.Testing
         public Saga<T> WhenSagaTimesOut()
         {
             var state = bus.PopTimeout();
-            
+
+            if (state == null)
+            {
+                throw new Exception("Unable to find a matching timeout state. Make sure 'When(Action<T> sagaIsInvoked)' or 'WhenHandling<TMessage>(Action<TMessage> initializeMessage = null)' for a message which requests a timeout is invoked before 'WhenSagasTimeout()'.");
+            }
+
             var method = saga.GetType().GetMethod("Timeout", new[] {state.GetType()});
-            
+
             return When(s => method.Invoke(s, new[] {state}));
         }
 
@@ -378,7 +383,7 @@ namespace NServiceBus.Testing
 
             if (saga.Completed)
                 throw new Exception("Assert failed. Saga has been completed.");
-            
+
             throw new Exception("Assert failed. Saga has not been completed.");
         }
 
@@ -442,7 +447,7 @@ namespace NServiceBus.Testing
                 return true;
             };
         }
-        
+
         private static Func<T1, T2, bool> CheckActionToFunc<T1, T2>(Action<T1, T2> check)
         {
             return (arg1, arg2) =>

--- a/src/NServiceBus.Testing/TimeoutManager.cs
+++ b/src/NServiceBus.Testing/TimeoutManager.cs
@@ -26,6 +26,11 @@
                 if (d < min)
                     min = d;
 
+            if (!storage.ContainsKey(min))
+            {
+                return null;
+            }
+
             var result = storage[min][0];
 
             storage[min].RemoveAt(0);


### PR DESCRIPTION
## Who's affected
 * Users trying to use `WhenSagaTimesOut` without previous call to `When` or `WhenHandle`

## Symptoms

```
Test.Saga<TimeoutSaga>()
                    .ExpectTimeoutToBeSetIn<MyTimeout>((state, expiresIn) => expiresIn == TimeSpan.FromDays(1))
                    .WhenSagaTimesOut()
```

will throw a `KeyNotFoundException` coming from the `TimeoutManager`. The problem is that this exception doesn't guide the user in any way to do the right thing. 