### PR TITLE
Handle inherited messages correctly

### DIFF
--- a/src/NServiceBus.Testing/Handler.cs
+++ b/src/NServiceBus.Testing/Handler.cs
@@ -301,13 +301,10 @@
         public void OnMessage<TMessage>(TMessage initializedMessage)
         {
             var messageType = messageCreator.GetMappedTypeFor(initializedMessage.GetType());
-            var handleMethod = handler.GetType().CreateInvoker(messageType, typeof(IHandleMessages<>));
-            if (handleMethod == null)
-            {
-                return;
-            }
+            var handleMethods = handler.GetType().CreateInvokers(messageType, typeof(IHandleMessages<>));
 
-            handleMethod(handler, initializedMessage, testableMessageHandlerContext).GetAwaiter().GetResult();
+            handleMethods.InvokeSerially(handler, initializedMessage, testableMessageHandlerContext).GetAwaiter().GetResult();
+
             testableMessageHandlerContext.Validate();
         }
 

--- a/src/NServiceBus.Testing/NServiceBus.Testing.csproj
+++ b/src/NServiceBus.Testing/NServiceBus.Testing.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props" Condition="Exists('..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -135,6 +136,9 @@
   <ItemGroup>
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Particular.CodeRules.0.1.1\tools\..\analyzers\dotnet\cs\Particular.CodeRules.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -143,6 +147,7 @@
     <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.3\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.3\build\dotnet\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props'))" />
   </Target>
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets')" />

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -259,9 +259,9 @@
         public Saga<T> WhenHandling<TMessage>(Action<TMessage> initializeMessage = null)
         {
             var message = messageCreator.CreateInstance(initializeMessage);
-            var invoker = saga.GetType().CreateInvoker(typeof(TMessage), typeof(IHandleMessages<>));
+            var invokers = saga.GetType().CreateInvokers(typeof(TMessage), typeof(IHandleMessages<>));
 
-            return When((s, c) => invoker(saga, message, c));
+            return When((s, c) => invokers.InvokeSerially(saga, message, c));
         }
 
         /// <summary>
@@ -271,9 +271,9 @@
         public Saga<T> WhenHandlingTimeout<TMessage>(Action<TMessage> initializeMessage = null)
         {
             var message = messageCreator.CreateInstance(initializeMessage);
-            var invoker = saga.GetType().CreateInvoker(typeof(TMessage), typeof(IHandleTimeouts<>));
+            var invokers = saga.GetType().CreateInvokers(typeof(TMessage), typeof(IHandleTimeouts<>));
 
-            return When((s, c) => invoker(saga, message, c));
+            return When((s, c) => invokers.InvokeSerially(saga, message, c));
         }
 
         /// <summary>
@@ -539,8 +539,8 @@
                 .ForEach(t =>
                 {
                     var messageType = messageCreator.GetMappedTypeFor(t.Message.GetType());
-                    var invoker = saga.GetType().CreateInvoker(messageType, typeof(IHandleTimeouts<>));
-                    invoker(saga, t.Message, testContext).GetAwaiter().GetResult();
+                    var invokers = saga.GetType().CreateInvokers(messageType, typeof(IHandleTimeouts<>));
+                    invokers.InvokeSerially(saga, t.Message, testContext).GetAwaiter().GetResult();
                 });
 
             testContext.Validate();

--- a/src/NServiceBus.Testing/TypeExtensions.cs
+++ b/src/NServiceBus.Testing/TypeExtensions.cs
@@ -1,39 +1,48 @@
 ﻿namespace NServiceBus.Testing
  {
      using System;
+     using System.Collections.Generic;
      using System.Linq;
      using System.Linq.Expressions;
      using System.Threading.Tasks;
- 
+
      static class TypeExtensions
      {
-         public static Func<object, object, IMessageHandlerContext, Task> CreateInvoker(this Type targetType, Type messageType, Type interfaceGenericType)
+         public static IEnumerable<Func<object, object, IMessageHandlerContext, Task>> CreateInvokers(this Type targetType, Type messageType, Type interfaceGenericType)
          {
-             var interfaceType = interfaceGenericType.MakeGenericType(messageType);
- 
-             if (!interfaceType.IsAssignableFrom(targetType))
+             var interfaceTypes = targetType.GetInterfaces()
+                 .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceGenericType)
+                 .Where(i => i.GenericTypeArguments.First().IsAssignableFrom(messageType));
+
+             foreach (var interfaceType in interfaceTypes)
              {
-                 return null;
-             }
- 
-             var methodInfo = targetType.GetInterfaceMap(interfaceType).TargetMethods.FirstOrDefault();
-             if (methodInfo == null)
-             {
-                 return null;
-             }
- 
-             var target = Expression.Parameter(typeof(object));
-             var messageParam = Expression.Parameter(typeof(object));
-             var contextParam = Expression.Parameter(typeof(IMessageHandlerContext));
- 
-             var castTarget = Expression.Convert(target, targetType);
- 
-             var methodParameters = methodInfo.GetParameters();
-             var messageCastParam = Expression.Convert(messageParam, methodParameters.ElementAt(0).ParameterType);
- 
-             Expression body = Expression.Call(castTarget, methodInfo, messageCastParam, contextParam);
- 
-             return Expression.Lambda<Func<object, object, IMessageHandlerContext, Task>>(body, target, messageParam, contextParam).Compile();
+                var methodInfo = targetType.GetInterfaceMap(interfaceType).TargetMethods.FirstOrDefault();
+                if (methodInfo == null)
+                {
+                    yield break;
+                }
+
+                var target = Expression.Parameter(typeof(object));
+                var messageParam = Expression.Parameter(typeof(object));
+                var contextParam = Expression.Parameter(typeof(IMessageHandlerContext));
+
+                var castTarget = Expression.Convert(target, targetType);
+
+                var methodParameters = methodInfo.GetParameters();
+                var messageCastParam = Expression.Convert(messageParam, methodParameters.ElementAt(0).ParameterType);
+
+                Expression body = Expression.Call(castTarget, methodInfo, messageCastParam, contextParam);
+
+                yield return Expression.Lambda<Func<object, object, IMessageHandlerContext, Task>>(body, target, messageParam, contextParam).Compile();
+            }
          }
+
+         public static async Task InvokeSerially(this IEnumerable<Func<object, object, IMessageHandlerContext, Task>> invokers, object instance, object message, IMessageHandlerContext context)
+         {
+            foreach (var invocation in invokers)
+            {
+                await invocation(instance, message, context);
+            }
+        }
      }
- } 
+ }

--- a/src/NServiceBus.Testing/TypeExtensions.cs
+++ b/src/NServiceBus.Testing/TypeExtensions.cs
@@ -41,7 +41,7 @@
          {
             foreach (var invocation in invokers)
             {
-                await invocation(instance, message, context);
+                await invocation(instance, message, context).ConfigureAwait(false);
             }
         }
      }

--- a/src/NServiceBus.Testing/packages.config
+++ b/src/NServiceBus.Testing/packages.config
@@ -6,4 +6,5 @@
   <package id="NServiceBus.Testing.Fakes.Sources" version="6.0.0" targetFramework="net452" />
   <package id="NuGetPackager" version="0.6.0" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />
+  <package id="Particular.CodeRules" version="0.1.1" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
fixes #95 

the testing framework isn't able to handle message hierarchies properly and also invokes only one handle method per message.

@Particular/nservicebus-maintainers please review