### PR TITLE
Support non-UTC time zones in Timeout assertions

### DIFF
--- a/src/NServiceBus.Testing.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/APIApprovals.Approve.approved.txt
@@ -29,13 +29,13 @@ namespace NServiceBus.Testing
     {
         public NServiceBus.Testing.Handler<T> ConfigureHandlerContext(System.Action<NServiceBus.Testing.TestableMessageHandlerContext> contextInitializer) { }
         public NServiceBus.Testing.Handler<T> ExpectDefer<TMessage>(System.Func<TMessage, System.TimeSpan, bool> check) { }
-        public NServiceBus.Testing.Handler<T> ExpectDefer<TMessage>(System.Func<TMessage, System.DateTime, bool> check) { }
+        public NServiceBus.Testing.Handler<T> ExpectDefer<TMessage>(System.Func<TMessage, System.DateTimeOffset, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectDoNotContinueDispatchingCurrentMessageToHandlers() { }
         public NServiceBus.Testing.Handler<T> ExpectForwardCurrentMessageTo(System.Func<string, bool> check = null) { }
         [System.ObsoleteAttribute("HandleCurrentMessageLater has been deprecated. Will be removed in version 8.0.0.", true)]
         public NServiceBus.Testing.Handler<T> ExpectHandleCurrentMessageLater() { }
         public NServiceBus.Testing.Handler<T> ExpectNotDefer<TMessage>(System.Func<TMessage, System.TimeSpan, bool> check) { }
-        public NServiceBus.Testing.Handler<T> ExpectNotDefer<TMessage>(System.Func<TMessage, System.DateTime, bool> check) { }
+        public NServiceBus.Testing.Handler<T> ExpectNotDefer<TMessage>(System.Func<TMessage, System.DateTimeOffset, bool> check) { }
         public NServiceBus.Testing.Handler<T> ExpectNotForwardCurrentMessageTo(System.Func<string, bool> check = null) { }
         public NServiceBus.Testing.Handler<T> ExpectNotPublish<TMessage>(System.Func<TMessage, NServiceBus.PublishOptions, bool> check = null) { }
         public NServiceBus.Testing.Handler<T> ExpectNotPublish<TMessage>(System.Func<TMessage, bool> check) { }
@@ -98,7 +98,7 @@ namespace NServiceBus.Testing
         [System.ObsoleteAttribute("HandleCurrentMessageLater has been deprecated. Will be removed in version 8.0.0.", true)]
         public NServiceBus.Testing.Saga<T> ExpectHandleCurrentMessageLater() { }
         public NServiceBus.Testing.Saga<T> ExpectNotForwardCurrentMessageTo(System.Func<string, bool> check = null) { }
-        public NServiceBus.Testing.Saga<T> ExpectNoTimeoutToBeSetAt<TMessage>(System.Func<TMessage, System.DateTime, bool> check = null) { }
+        public NServiceBus.Testing.Saga<T> ExpectNoTimeoutToBeSetAt<TMessage>(System.Func<TMessage, System.DateTimeOffset, bool> check = null) { }
         public NServiceBus.Testing.Saga<T> ExpectNoTimeoutToBeSetIn<TMessage>(System.Func<TMessage, System.TimeSpan, bool> check = null) { }
         public NServiceBus.Testing.Saga<T> ExpectNotPublish<TMessage>(System.Func<TMessage, NServiceBus.PublishOptions, bool> check = null) { }
         public NServiceBus.Testing.Saga<T> ExpectNotPublish<TMessage>(System.Func<TMessage, bool> check) { }
@@ -130,8 +130,8 @@ namespace NServiceBus.Testing
         public NServiceBus.Testing.Saga<T> ExpectSendLocal<TMessage>(System.Action<TMessage> check) { }
         public NServiceBus.Testing.Saga<T> ExpectSendToDestination<TMessage>(System.Func<TMessage, string, bool> check = null) { }
         public NServiceBus.Testing.Saga<T> ExpectSendToDestination<TMessage>(System.Action<TMessage, string> check) { }
-        public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetAt<TMessage>(System.Func<TMessage, System.DateTime, bool> check = null) { }
-        public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetAt<TMessage>(System.Action<TMessage, System.DateTime> check) { }
+        public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetAt<TMessage>(System.Func<TMessage, System.DateTimeOffset, bool> check = null) { }
+        public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetAt<TMessage>(System.Action<TMessage, System.DateTimeOffset> check) { }
         public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetIn<TMessage>(System.Func<TMessage, System.TimeSpan, bool> check = null) { }
         public NServiceBus.Testing.Saga<T> ExpectTimeoutToBeSetIn<TMessage>(System.Action<TMessage, System.TimeSpan> check) { }
         public NServiceBus.Testing.Saga<T> SetIncomingHeader(string key, string value) { }

--- a/src/NServiceBus.Testing.Tests/Handler/ExpectDeferTests.cs
+++ b/src/NServiceBus.Testing.Tests/Handler/ExpectDeferTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Testing.Tests.Handler
+namespace NServiceBus.Testing.Tests.Handler
 {
     using System;
     using System.Threading.Tasks;
@@ -21,6 +21,16 @@
         public void ShouldAssertDeferWasCalledWithDateTime()
         {
             var datetime = DateTime.UtcNow;
+            Test.Handler<DeferringDateTimeHandler>()
+                .WithExternalDependencies(h => h.Defer = datetime)
+                .ExpectDefer<TestMessage>((m, t) => t == datetime)
+                .OnMessage<TestMessage>();
+        }
+
+        [Test]
+        public void ShouldAssertDeferWasCalledWithLocalDateTime()
+        {
+            var datetime = DateTime.Now;
             Test.Handler<DeferringDateTimeHandler>()
                 .WithExternalDependencies(h => h.Defer = datetime)
                 .ExpectDefer<TestMessage>((m, t) => t == datetime)

--- a/src/NServiceBus.Testing.Tests/Saga/ExpectTimeoutTests.cs
+++ b/src/NServiceBus.Testing.Tests/Saga/ExpectTimeoutTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Testing.Tests.Saga
+namespace NServiceBus.Testing.Tests.Saga
 {
     using System;
     using System.Threading.Tasks;
@@ -40,6 +40,20 @@
         public void TimeoutInTheFuture()
         {
             var expected = DateTime.UtcNow.AddDays(3);
+            var message = new TheMessage
+            {
+                TimeoutAt = expected
+            };
+
+            Test.Saga<TimeoutSaga>()
+                .ExpectTimeoutToBeSetAt<TheTimeout>((m, at) => at == expected)
+                .When((s, c) => s.Handle(message, c));
+        }
+
+        [Test]
+        public void TimeoutInLocalTimeInTheFuture()
+        {
+            var expected = DateTime.Now.AddDays(3);
             var message = new TheMessage
             {
                 TimeoutAt = expected

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectDoNotDeliverBefore.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectDoNotDeliverBefore.cs
@@ -1,11 +1,11 @@
-﻿namespace NServiceBus.Testing
+namespace NServiceBus.Testing
 {
     using System;
     using System.Linq;
 
     class ExpectDoNotDeliverBefore<TMessage> : ExpectInvocation
     {
-        public ExpectDoNotDeliverBefore(Func<TMessage, DateTime, bool> check = null)
+        public ExpectDoNotDeliverBefore(Func<TMessage, DateTimeOffset, bool> check = null)
         {
             this.check = check ?? ((m, d) => true);
         }
@@ -17,12 +17,12 @@
                 .Where(s => s.Options.GetDeliveryDate().HasValue)
                 .ToList();
 
-            if (!sentMessages.Any(s => check(s.Message, s.Options.GetDeliveryDate().Value.DateTime)))
+            if (!sentMessages.Any(s => check(s.Message, s.Options.GetDeliveryDate().Value)))
             {
                 Fail($"Expected a message of type {typeof(TMessage).Name} to be deferred, but no message matching your constraints was deferred.");
             }
         }
 
-        readonly Func<TMessage, DateTime, bool> check;
+        readonly Func<TMessage, DateTimeOffset, bool> check;
     }
 }

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDoNotDeliverBefore.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDoNotDeliverBefore.cs
@@ -1,11 +1,11 @@
-﻿namespace NServiceBus.Testing
+namespace NServiceBus.Testing
 {
     using System;
     using System.Linq;
 
     class ExpectNotDoNotDeliverBefore<TMessage> : ExpectInvocation
     {
-        public ExpectNotDoNotDeliverBefore(Func<TMessage, DateTime, bool> check = null)
+        public ExpectNotDoNotDeliverBefore(Func<TMessage, DateTimeOffset, bool> check = null)
         {
             this.check = check ?? ((m, d) => true);
         }
@@ -17,12 +17,12 @@
                 .Where(s => s.Options.GetDeliveryDate().HasValue)
                 .ToList();
 
-            if (sentMessages.Any(s => check(s.Message, s.Options.GetDeliveryDate().Value.DateTime)))
+            if (sentMessages.Any(s => check(s.Message, s.Options.GetDeliveryDate().Value)))
             {
                 Fail($"Expected no message of type {typeof(TMessage).Name} to be deferred, but a message matching your constraints was deferred.");
             }
         }
 
-        readonly Func<TMessage, DateTime, bool> check;
+        readonly Func<TMessage, DateTimeOffset, bool> check;
     }
 }

--- a/src/NServiceBus.Testing/Handler.cs
+++ b/src/NServiceBus.Testing/Handler.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Testing
+namespace NServiceBus.Testing
 {
     using System;
     using MessageInterfaces.MessageMapper.Reflection;
@@ -191,7 +191,7 @@
         /// <summary>
         /// Check that the handler defers a message of the given type.
         /// </summary>
-        public Handler<T> ExpectDefer<TMessage>(Func<TMessage, DateTime, bool> check)
+        public Handler<T> ExpectDefer<TMessage>(Func<TMessage, DateTimeOffset, bool> check)
         {
             testableMessageHandlerContext.AddExpectation(new ExpectDoNotDeliverBefore<TMessage>(check));
             return this;
@@ -209,7 +209,7 @@
         /// <summary>
         /// Check that the handler doesn't defer a message of the given type.
         /// </summary>
-        public Handler<T> ExpectNotDefer<TMessage>(Func<TMessage, DateTime, bool> check)
+        public Handler<T> ExpectNotDefer<TMessage>(Func<TMessage, DateTimeOffset, bool> check)
         {
             testableMessageHandlerContext.AddExpectation(new ExpectNotDoNotDeliverBefore<TMessage>(check));
             return this;

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Testing
+namespace NServiceBus.Testing
 {
     using System;
     using System.Collections.Generic;
@@ -409,7 +409,7 @@
         /// <summary>
         /// Verifies that the saga is setting the specified timeout
         /// </summary>
-        public Saga<T> ExpectTimeoutToBeSetAt<TMessage>(Func<TMessage, DateTime, bool> check = null)
+        public Saga<T> ExpectTimeoutToBeSetAt<TMessage>(Func<TMessage, DateTimeOffset, bool> check = null)
         {
             testContext.AddExpectation(new ExpectDoNotDeliverBefore<TMessage>(check));
             return this;
@@ -418,7 +418,7 @@
         /// <summary>
         /// Verifies that the saga is setting the specified timeout
         /// </summary>
-        public Saga<T> ExpectTimeoutToBeSetAt<TMessage>(Action<TMessage, DateTime> check)
+        public Saga<T> ExpectTimeoutToBeSetAt<TMessage>(Action<TMessage, DateTimeOffset> check)
         {
             return ExpectTimeoutToBeSetAt(CheckActionToFunc(check));
         }
@@ -426,7 +426,7 @@
         /// <summary>
         /// Verifies that the saga is not setting the specified timeout
         /// </summary>
-        public Saga<T> ExpectNoTimeoutToBeSetAt<TMessage>(Func<TMessage, DateTime, bool> check = null)
+        public Saga<T> ExpectNoTimeoutToBeSetAt<TMessage>(Func<TMessage, DateTimeOffset, bool> check = null)
         {
             testContext.AddExpectation(new ExpectNotDoNotDeliverBefore<TMessage>(check));
             return this;


### PR DESCRIPTION
This PR is intended as a way to demonstrate/discuss what I think is a minor bug in the "old" testing framework. Assertions on non-UTC date times don't work

Change Timeout expectations from DateTime to DateTimeOffset in order to allow assertions on non-UTC time zones.