### PR TITLE
Ability to scope the TestingLoggerFactory

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -351,6 +351,7 @@ namespace NServiceBus.Testing
         public TestingLoggerFactory() { }
         protected override NServiceBus.Logging.ILoggerFactory GetLoggingFactory() { }
         public void Level(NServiceBus.Logging.LogLevel level) { }
+        public System.IDisposable Use(System.IO.TextWriter writer, NServiceBus.Logging.LogLevel level = 0) { }
         public void WriteTo(System.IO.TextWriter writer) { }
     }
     public class TimeoutMessage<TMessage> : NServiceBus.Testing.OutgoingMessage<TMessage, NServiceBus.SendOptions>

--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -349,9 +349,9 @@ namespace NServiceBus.Testing
     public class TestingLoggerFactory : NServiceBus.Logging.LoggingFactoryDefinition
     {
         public TestingLoggerFactory() { }
+        public System.IDisposable BeginScope(System.IO.TextWriter writer, NServiceBus.Logging.LogLevel level = 0) { }
         protected override NServiceBus.Logging.ILoggerFactory GetLoggingFactory() { }
         public void Level(NServiceBus.Logging.LogLevel level) { }
-        public System.IDisposable Use(System.IO.TextWriter writer, NServiceBus.Logging.LogLevel level = 0) { }
         public void WriteTo(System.IO.TextWriter writer) { }
     }
     public class TimeoutMessage<TMessage> : NServiceBus.Testing.OutgoingMessage<TMessage, NServiceBus.SendOptions>

--- a/src/NServiceBus.Testing.Tests/Logging/LoggingForFixtureTests.cs
+++ b/src/NServiceBus.Testing.Tests/Logging/LoggingForFixtureTests.cs
@@ -1,0 +1,50 @@
+namespace NServiceBus.Testing.Tests.Logging
+{
+    using System;
+    using System.IO;
+    using NServiceBus.Logging;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Parallelizable]
+    public class LoggingForFixtureTests
+    {
+        StringWriter writer;
+        IDisposable scope;
+
+        [SetUp]
+        public void Setup()
+        {
+            writer = new StringWriter();
+            
+            this.scope = LogManager.Use<TestingLoggerFactory>()
+                .Use(writer);
+        }
+
+        [Test]
+        public void Should_write_first_independent_from_other()
+        {
+            var Logger = LogManager.GetLogger<LoggingForFixtureTests>();
+            Logger.Debug("First");
+            
+            StringAssert.Contains("NServiceBus.Testing.Tests.Logging.LoggingForFixtureTests First", writer.ToString());
+            StringAssert.DoesNotContain("NServiceBus.Testing.Tests.Logging.LoggingForFixtureTests Second", writer.ToString());
+        }
+        
+        [Test]
+        public void Should_write_second_independent_from_other()
+        {
+            var Logger = LogManager.GetLogger<LoggingForFixtureTests>();
+            Logger.Debug("Second");
+            
+            StringAssert.Contains("NServiceBus.Testing.Tests.Logging.LoggingForFixtureTests Second", writer.ToString());
+            StringAssert.DoesNotContain("NServiceBus.Testing.Tests.Logging.LoggingForFixtureTests First", writer.ToString());
+        }
+        
+        [TearDown]
+        public void Teardown()
+        {
+            scope.Dispose();
+        }
+    }
+}

--- a/src/NServiceBus.Testing.Tests/Logging/LoggingForFixtureTests.cs
+++ b/src/NServiceBus.Testing.Tests/Logging/LoggingForFixtureTests.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Testing.Tests.Logging
             writer = new StringWriter();
             
             this.scope = LogManager.Use<TestingLoggerFactory>()
-                .Use(writer);
+                .BeginScope(writer);
         }
 
         [Test]

--- a/src/NServiceBus.Testing.Tests/Logging/LoggingTests.cs
+++ b/src/NServiceBus.Testing.Tests/Logging/LoggingTests.cs
@@ -1,0 +1,144 @@
+namespace NServiceBus.Testing.Tests.Logging
+{
+    using System;
+    using System.IO;
+    using NServiceBus.Logging;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class LoggingTests
+    {
+        [TearDown]
+        public void Teardown()
+        {
+            SomeClassThatUsesStaticLogger.Reset();
+        }
+        
+        [Test]
+        public void Scoped_Writer_should_be_honored()
+        {
+            var firstStringWriter = new StringWriter();
+            var loggerFactory = LogManager.Use<TestingLoggerFactory>();
+            using (loggerFactory.Use(firstStringWriter))
+            {
+                var firstInstance = new SomeClassThatUsesStaticLogger();
+                firstInstance.DoSomething();
+            }
+
+            var secondStringWriter = new StringWriter();
+            using (loggerFactory.Use(secondStringWriter))
+            {
+                var secondInstance = new SomeClassThatUsesStaticLogger();
+                secondInstance.DoSomething();
+            }
+
+            var firstLogString = firstStringWriter.ToString();
+            var secondLogString = secondStringWriter.ToString();
+
+            Assert.AreNotEqual(firstLogString, secondLogString);
+            StringAssert.Contains("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 0", firstLogString);
+            StringAssert.DoesNotContain("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 1", firstLogString);
+            StringAssert.Contains("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 1", secondLogString);
+            StringAssert.DoesNotContain("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 0", secondLogString);
+        }
+
+        [Test]
+        public void Scoped_Loglevel_should_be_honored()
+        {
+            var firstStringWriter = new StringWriter();
+            var loggerFactory = LogManager.Use<TestingLoggerFactory>();
+            using (loggerFactory.Use(firstStringWriter, LogLevel.Warn))
+            {
+                var firstInstance = new SomeClassThatUsesStaticLogger();
+                firstInstance.DoSomething();
+            }
+
+            var secondStringWriter = new StringWriter();
+            using (loggerFactory.Use(secondStringWriter))
+            {
+                var secondInstance = new SomeClassThatUsesStaticLogger();
+                secondInstance.DoSomething();
+            }
+
+            var firstLogString = firstStringWriter.ToString();
+            var secondLogString = secondStringWriter.ToString();
+
+            Assert.AreNotEqual(firstLogString, secondLogString);
+            Assert.IsEmpty(firstLogString);
+            StringAssert.Contains("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 1", secondLogString);
+        }
+
+        [Test]
+        public void Global_Writer_should_be_honored()
+        {
+            var loggerFactory = LogManager.Use<TestingLoggerFactory>();
+            var globalWriter = new StringWriter();
+            loggerFactory.WriteTo(globalWriter);
+            
+            var firstInstance = new SomeClassThatUsesStaticLogger();
+            firstInstance.DoSomething();
+            
+            var secondStringWriter = new StringWriter();
+            using (loggerFactory.Use(secondStringWriter))
+            {
+                var secondInstance = new SomeClassThatUsesStaticLogger();
+                secondInstance.DoSomething();
+            }
+            
+            var globalLogString = globalWriter.ToString();
+            var scopedLogString = secondStringWriter.ToString();
+
+            Assert.AreNotEqual(globalLogString, scopedLogString);
+            StringAssert.Contains("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 0", globalLogString);
+            StringAssert.DoesNotContain("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 1", globalLogString);
+            StringAssert.Contains("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 1", scopedLogString);
+            StringAssert.DoesNotContain("NServiceBus.Testing.Tests.Logging.LoggingTests+SomeClassThatUsesStaticLogger 0", scopedLogString);
+        }
+
+        [Test]
+        public void Scope_cannot_be_nested()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var loggerFactory = LogManager.Use<TestingLoggerFactory>();
+                using (loggerFactory.Use(new StringWriter()))
+                using (loggerFactory.Use(new StringWriter()))
+                {
+                }
+            });
+        }
+
+        [Test]
+        public void NoScope_does_work()
+        {
+            LogManager.Use<TestingLoggerFactory>();
+
+            var secondInstance = new SomeClassThatUsesStaticLogger();
+            secondInstance.DoSomething();
+        }
+
+        class SomeClassThatUsesStaticLogger
+        {
+            public SomeClassThatUsesStaticLogger()
+            {
+                InstanceCounter = instanceCounter++;
+            }
+
+            public int InstanceCounter { get; }
+
+            public void DoSomething()
+            {
+                Logger.Debug(InstanceCounter.ToString());
+            }
+
+            public static void Reset()
+            {
+                instanceCounter = 0;
+            }
+
+            static int instanceCounter;
+
+            static ILog Logger = LogManager.GetLogger<SomeClassThatUsesStaticLogger>();
+        }
+    }
+}

--- a/src/NServiceBus.Testing.Tests/Logging/LoggingTests.cs
+++ b/src/NServiceBus.Testing.Tests/Logging/LoggingTests.cs
@@ -19,14 +19,14 @@ namespace NServiceBus.Testing.Tests.Logging
         {
             var firstStringWriter = new StringWriter();
             var loggerFactory = LogManager.Use<TestingLoggerFactory>();
-            using (loggerFactory.Use(firstStringWriter))
+            using (loggerFactory.BeginScope(firstStringWriter))
             {
                 var firstInstance = new SomeClassThatUsesStaticLogger();
                 firstInstance.DoSomething();
             }
 
             var secondStringWriter = new StringWriter();
-            using (loggerFactory.Use(secondStringWriter))
+            using (loggerFactory.BeginScope(secondStringWriter))
             {
                 var secondInstance = new SomeClassThatUsesStaticLogger();
                 secondInstance.DoSomething();
@@ -47,14 +47,14 @@ namespace NServiceBus.Testing.Tests.Logging
         {
             var firstStringWriter = new StringWriter();
             var loggerFactory = LogManager.Use<TestingLoggerFactory>();
-            using (loggerFactory.Use(firstStringWriter, LogLevel.Warn))
+            using (loggerFactory.BeginScope(firstStringWriter, LogLevel.Warn))
             {
                 var firstInstance = new SomeClassThatUsesStaticLogger();
                 firstInstance.DoSomething();
             }
 
             var secondStringWriter = new StringWriter();
-            using (loggerFactory.Use(secondStringWriter))
+            using (loggerFactory.BeginScope(secondStringWriter))
             {
                 var secondInstance = new SomeClassThatUsesStaticLogger();
                 secondInstance.DoSomething();
@@ -79,7 +79,7 @@ namespace NServiceBus.Testing.Tests.Logging
             firstInstance.DoSomething();
             
             var secondStringWriter = new StringWriter();
-            using (loggerFactory.Use(secondStringWriter))
+            using (loggerFactory.BeginScope(secondStringWriter))
             {
                 var secondInstance = new SomeClassThatUsesStaticLogger();
                 secondInstance.DoSomething();
@@ -101,8 +101,8 @@ namespace NServiceBus.Testing.Tests.Logging
             Assert.Throws<InvalidOperationException>(() =>
             {
                 var loggerFactory = LogManager.Use<TestingLoggerFactory>();
-                using (loggerFactory.Use(new StringWriter()))
-                using (loggerFactory.Use(new StringWriter()))
+                using (loggerFactory.BeginScope(new StringWriter()))
+                using (loggerFactory.BeginScope(new StringWriter()))
                 {
                 }
             });

--- a/src/NServiceBus.Testing.sln.DotSettings
+++ b/src/NServiceBus.Testing.sln.DotSettings
@@ -1,12 +1,17 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">Default</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InheritdocConsiderUsage/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InlineOutVariableDeclaration/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeCastWithTypeCheck/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UsePatternMatching/@EntryIndexedValue">ERROR</s:String>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Localization/CSharpLocalizationOptions/DontAnalyseVerbatimStrings/@EntryValue">False</s:Boolean>
 	
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002A_005C_002APackages_005C_002A_002A_005C_002A_002E_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=3D880FCA_002DD2DA_002D4AB9_002D8017_002DBA8B7C86D359_002Fd_003AApp_005FPackages/@EntryIndexedValue">ExplicitlyExcluded</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">SUGGESTION</s:String>
@@ -45,6 +50,13 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyGeneralCatchClause/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyNamespace/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyStatement/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceDoWhileStatementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceFixedStatementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceForeachStatementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceForStatementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceIfStatementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceLockStatementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceWhileStatementBraces/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EventNeverInvoked/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ExpressionIsAlwaysNull/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
@@ -112,6 +124,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022TryStatementsCanBeMerged_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022UnknownCssVendorExtension_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CStaticSeverity_0020Severity_003D_00222_0022_0020Title_003D_0022Structural_0020Search_0020Hints_0022_0020GroupId_003D_0022StructuralSearch_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveRedundantBraces/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SealedMemberInSealedClass/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StaticFieldInGenericType/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEverywhere/@EntryIndexedValue">ERROR</s:String>
@@ -139,6 +152,10 @@
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Format_0020My_0020Code_0020Using_0020_0022Particular_0022_0020conventions/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Format My Code Using &amp;quot;Particular&amp;quot; conventions"&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;JsInsertSemicolon&gt;True&lt;/JsInsertSemicolon&gt;&lt;JsReformatCode&gt;True&lt;/JsReformatCode&gt;&lt;CssReformatCode&gt;True&lt;/CssReformatCode&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;CssAlphabetizeProperties&gt;True&lt;/CssAlphabetizeProperties&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Default: Reformat Code</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">Format My Code Using "Particular" conventions</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOR/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOREACH/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_WHILE/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_INTERNAL_MODIFIER/@EntryValue">False</s:Boolean>
@@ -148,6 +165,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_IFELSE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_FIXED_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_SIZEOF_PARENTHESES/@EntryValue">False</s:Boolean>
@@ -590,9 +608,14 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/AsyncLocal.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/AsyncLocal.cs
@@ -1,0 +1,36 @@
+#if NETFRAMEWORK
+namespace System.Threading
+{
+    using Runtime.Remoting.Messaging;
+
+    // Provides a polyfill of AsyncLocal in .NET 4.5.2
+    sealed class AsyncLocal<T>
+    {
+        readonly string id;
+
+        // Gets or sets the value of the ambient data.
+        public T Value
+        {
+            get
+            {
+                var localValue = CallContext.LogicalGetData(id);
+                if (localValue != null)
+                {
+                    return (T)localValue;
+                }
+                return default;
+            }
+            set
+            {
+                // ReSharper disable once ArrangeAccessorOwnerBody
+                CallContext.LogicalSetData(id, value);
+            }
+        }
+
+        public AsyncLocal()
+        {
+            id = Guid.NewGuid().ToString();
+        }
+    }
+}
+#endif

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/NamedLogger.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/NamedLogger.cs
@@ -5,94 +5,95 @@ namespace NServiceBus.Testing
 
     class NamedLogger : ILog
     {
-        public NamedLogger(string name, DefaultTestingLoggerFactory defaultLoggerFactory)
+        public NamedLogger(string name)
         {
             this.name = name;
-            this.defaultLoggerFactory = defaultLoggerFactory;
         }
 
-        public bool IsDebugEnabled { get; internal set; }
-        public bool IsInfoEnabled { get; internal set; }
-        public bool IsWarnEnabled { get; internal set; }
-        public bool IsErrorEnabled { get; internal set; }
-        public bool IsFatalEnabled { get; internal set; }
+        public bool IsDebugEnabled => DefaultTestingLoggerFactory.IsDebugEnabled;
+        public bool IsInfoEnabled => DefaultTestingLoggerFactory.IsInfoEnabled;
+        
+        public bool IsWarnEnabled => DefaultTestingLoggerFactory.IsWarnEnabled;
+        
+        public bool IsErrorEnabled => DefaultTestingLoggerFactory.IsErrorEnabled;
+        
+        public bool IsFatalEnabled => DefaultTestingLoggerFactory.IsFatalEnabled;
 
         public void Debug(string message)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Debug, message);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Debug, message);
         }
 
         public void Debug(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + exception);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + exception);
         }
 
         public void DebugFormat(string format, params object[] args)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, args));
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, args));
         }
 
         public void Info(string message)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Info, message);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Info, message);
         }
 
         public void Info(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + exception);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + exception);
         }
 
         public void InfoFormat(string format, params object[] args)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, args));
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Info, string.Format(format, args));
         }
 
         public void Warn(string message)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Warn, message);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Warn, message);
         }
 
         public void Warn(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + exception);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + exception);
         }
 
         public void WarnFormat(string format, params object[] args)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, args));
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, args));
         }
 
         public void Error(string message)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, message);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Error, message);
         }
 
         public void Error(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
         }
 
         public void ErrorFormat(string format, params object[] args)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, args));
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Error, string.Format(format, args));
         }
 
         public void Fatal(string message)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Fatal, message);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Fatal, message);
         }
 
         public void Fatal(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
         }
 
         public void FatalFormat(string format, params object[] args)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, args));
+            DefaultTestingLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, args));
         }
 
-        DefaultTestingLoggerFactory defaultLoggerFactory;
         string name;
     }
 }

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Threading;
     using Logging;
 
     /// <summary>
@@ -14,25 +15,37 @@
         /// </summary>
         public TestingLoggerFactory()
         {
-            level = new Lazy<LogLevel>(() => LogLevel.Debug);
-            writer = new Lazy<TextWriter>(() => TextWriter.Null);
+            lazyLevel = new Lazy<LogLevel>(() => LogLevel.Debug);
+            lazyWriter = new Lazy<TextWriter>(() => TextWriter.Null);
         }
 
         /// <summary>
-        /// Controls the <see cref="Logging.LogLevel" />.
+        /// Controls the <see cref="Logging.LogLevel" /> for all default logging.
         /// </summary>
+        /// <param name="level">The log level to be used.</param>
         public void Level(LogLevel level)
         {
-            this.level = new Lazy<LogLevel>(() => level);
+            lazyLevel = new Lazy<LogLevel>(() => level);
         }
 
         /// <summary>
-        /// Instructs the logger to write to the provided text writer.
+        /// Instructs the logger to write to the provided text writer for all default logging.
         /// </summary>
         /// <param name="writer">The text writer to be used.</param>
         public void WriteTo(TextWriter writer)
         {
-            this.writer = new Lazy<TextWriter>(() => writer);
+            lazyWriter = new Lazy<TextWriter>(() => writer);
+        }
+
+        /// <summary>
+        /// Instructs the logger to write to the provided text writer for the given scope.
+        /// </summary>
+        /// <param name="writer">The text writer to be used.</param>
+        /// <param name="level">The log level to be used.</param>
+        /// <returns>The logging scope. Cannot be nested.</returns>
+        public IDisposable Use(TextWriter writer, LogLevel level = LogLevel.Debug)
+        {
+            return new Scope(this, writer, level);
         }
 
         /// <summary>
@@ -40,13 +53,34 @@
         /// </summary>
         protected override ILoggerFactory GetLoggingFactory()
         {
-            var loggerFactory = new DefaultTestingLoggerFactory(level.Value, writer.Value);
-            var message = $"Logging to testing logger with level {level}";
-            loggerFactory.Write(GetType().Name, LogLevel.Info, message);
-            return loggerFactory;
+            if (testingLoggerFactory == null)
+            {
+                testingLoggerFactory = new DefaultTestingLoggerFactory();
+            }
+            return testingLoggerFactory;
         }
 
-        Lazy<LogLevel> level;
-        Lazy<TextWriter> writer;
+        internal static AsyncLocal<Tuple<TextWriter, LogLevel>> currentScope = new AsyncLocal<Tuple<TextWriter, LogLevel>>();
+        internal static Lazy<LogLevel> lazyLevel;
+        internal static Lazy<TextWriter> lazyWriter;
+        static DefaultTestingLoggerFactory testingLoggerFactory;
+
+        class Scope : IDisposable
+        {
+            public Scope(TestingLoggerFactory factory, TextWriter writer, LogLevel logLevel)
+            {
+                if (currentScope.Value != null)
+                {
+                    throw new InvalidOperationException("Nesting of logging scopes is not allowed.");
+                }
+
+                currentScope.Value = Tuple.Create(writer, logLevel);
+            }
+
+            public void Dispose()
+            {
+                currentScope.Value = null;
+            }
+        }
     }
 }

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
@@ -45,7 +45,7 @@
         /// <returns>The logging scope. Cannot be nested.</returns>
         public IDisposable BeginScope(TextWriter writer, LogLevel level = LogLevel.Debug)
         {
-            return new Scope(this, writer, level);
+            return new Scope(writer, level);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@
 
         class Scope : IDisposable
         {
-            public Scope(TestingLoggerFactory factory, TextWriter writer, LogLevel logLevel)
+            public Scope(TextWriter writer, LogLevel logLevel)
             {
                 if (currentScope.Value != null)
                 {

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
@@ -57,6 +57,7 @@
             {
                 testingLoggerFactory = new DefaultTestingLoggerFactory();
             }
+
             return testingLoggerFactory;
         }
 

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
@@ -43,7 +43,7 @@
         /// <param name="writer">The text writer to be used.</param>
         /// <param name="level">The log level to be used.</param>
         /// <returns>The logging scope. Cannot be nested.</returns>
-        public IDisposable Use(TextWriter writer, LogLevel level = LogLevel.Debug)
+        public IDisposable BeginScope(TextWriter writer, LogLevel level = LogLevel.Debug)
         {
             return new Scope(this, writer, level);
         }


### PR DESCRIPTION
The testing logging factory is kind of broken. When you write a test like

```
[Test]
    public async Task ShouldLogCorrectly()
    {
        var logStatements = new StringBuilder();

        LogManager.Use<TestingLoggerFactory>()
            .WriteTo(new StringWriter(logStatements));

        var handler = new MyHandlerWithLogging();

        await handler.Handle(new MyRequest(), new TestableMessageHandlerContext())
            .ConfigureAwait(false);

        StringAssert.Contains("Some log message", logStatements.ToString());
    }
```

and then write another test like

```
[Test]
    public async Task ShouldLogCorrectlyASecondTime()
    {
        var logStatements = new StringBuilder();

        LogManager.Use<TestingLoggerFactory>()
            .WriteTo(new StringWriter(logStatements));

        var handler = new MyHandlerWithLogging();

        await handler.Handle(new MyRequest(), new TestableMessageHandlerContext())
            .ConfigureAwait(false);

        StringAssert.Contains("Some log message", logStatements.ToString());
    }
```

Whichever test executed first the string writer is set. So in case the first step executes the second test will fail. To better explain those side effects I recently [augmented the documentation a bit](https://github.com/Particular/docs.particular.net/pull/4478/) to show how the current implementation can be used

```
[SetUpFixture]
public class LoggingSetupFixture
{
    static readonly StringBuilder logStatements = new StringBuilder();

    [OneTimeSetUp]
    public void SetUp()
    {
        LogManager.Use<TestingLoggerFactory>()
            .WriteTo(new StringWriter(logStatements));
    }

    public static string LogStatements => logStatements.ToString();

    public static void Clear()
    {
        logStatements.Clear();
    }
}

[TestFixture]
public class LoggingTests
{
    #region LoggerTesting

    [SetUp]
    public void SetUp()
    {
        LoggingSetupFixture.Clear();
    }

    [Test]
    public async Task ShouldLogCorrectly()
    {
        var logStatements = new StringBuilder();

        LogManager.Use<TestingLoggerFactory>()
            .WriteTo(new StringWriter(logStatements));

        var handler = new MyHandlerWithLogging();

        await handler.Handle(new MyRequest(), new TestableMessageHandlerContext())
            .ConfigureAwait(false);

        StringAssert.Contains("Some log message", logStatements.ToString());
        StringAssert.Contains("Some log message", LoggingSetupFixture.LogStatements);
    }

    #endregion
} 
```

But this clearly shows that the testing logging factory cannot be used concurrently. So if you have any test parallelization or multiple handlers involved it would fail. This PR addressed this by introducing a scope that allows managing a writer and a log level for the lifetime of the scope. The tests should give an indication of the benefits of this approach



