### PR TITLE
Async overloads for OnMessage and When

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -58,6 +58,10 @@ namespace NServiceBus.Testing
         public void OnMessage<TMessage>(System.Action<TMessage> initializeMessage = null) { }
         public void OnMessage<TMessage>(TMessage message, string messageId) { }
         public void OnMessage<TMessage>(TMessage initializedMessage) { }
+        public System.Threading.Tasks.Task OnMessageAsync<TMessage>(string messageId, System.Action<TMessage> initializeMessage = null) { }
+        public System.Threading.Tasks.Task OnMessageAsync<TMessage>(System.Action<TMessage> initializeMessage = null) { }
+        public System.Threading.Tasks.Task OnMessageAsync<TMessage>(TMessage message, string messageId) { }
+        public System.Threading.Tasks.Task OnMessageAsync<TMessage>(TMessage initializedMessage) { }
         public NServiceBus.Testing.Handler<T> SetIncomingHeader(string key, string value) { }
         public NServiceBus.Testing.Handler<T> WithExternalDependencies(System.Action<T> actionToSetUpExternalDependencies) { }
     }
@@ -139,14 +143,24 @@ namespace NServiceBus.Testing
         public NServiceBus.Testing.Saga<T> When(System.Func<T, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task> sagaIsInvoked) { }
         public NServiceBus.Testing.Saga<T> When<TMessage>(System.Func<T, System.Func<TMessage, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task>> handlerSelector, TMessage message) { }
         public NServiceBus.Testing.Saga<T> When<TMessage>(System.Func<T, System.Func<TMessage, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task>> handlerSelector, System.Action<TMessage> messageInitializer = null) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenAsync(System.Func<T, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task> sagaIsInvoked) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenAsync<TMessage>(System.Func<T, System.Func<TMessage, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task>> handlerSelector, TMessage message) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenAsync<TMessage>(System.Func<T, System.Func<TMessage, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task>> handlerSelector, System.Action<TMessage> messageInitializer = null) { }
         public NServiceBus.Testing.Saga<T> WhenHandling<TMessage>(System.Action<TMessage> initializeMessage = null) { }
         public NServiceBus.Testing.Saga<T> WhenHandling<TMessage>(TMessage message) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenHandlingAsync<TMessage>(System.Action<TMessage> initializeMessage = null) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenHandlingAsync<TMessage>(TMessage message) { }
         public NServiceBus.Testing.Saga<T> WhenHandlingTimeout<TMessage>(System.Action<TMessage> initializeMessage = null) { }
         public NServiceBus.Testing.Saga<T> WhenHandlingTimeout<TMessage>(TMessage message) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenHandlingTimeoutAsync<TMessage>(System.Action<TMessage> initializeMessage = null) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenHandlingTimeoutAsync<TMessage>(TMessage message) { }
         public NServiceBus.Testing.Saga<T> WhenReceivesMessageFrom(string client) { }
         public NServiceBus.Testing.Saga<T> WhenSagaTimesOut(System.TimeSpan after) { }
         public NServiceBus.Testing.Saga<T> WhenSagaTimesOut(System.DateTime at) { }
         public NServiceBus.Testing.Saga<T> WhenSagaTimesOut() { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenSagaTimesOutAsync(System.TimeSpan after) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenSagaTimesOutAsync(System.DateTime at) { }
+        public System.Threading.Tasks.Task<NServiceBus.Testing.Saga<T>> WhenSagaTimesOutAsync() { }
         public NServiceBus.Testing.Saga<T> WithExternalDependencies(System.Action<T> actionToSetUpExternalDependencies) { }
     }
     public class SentMessage<TMessage> : NServiceBus.Testing.OutgoingMessage<TMessage, NServiceBus.SendOptions>

--- a/src/NServiceBus.Testing/TypeExtensions.cs
+++ b/src/NServiceBus.Testing/TypeExtensions.cs
@@ -1,21 +1,21 @@
 ﻿namespace NServiceBus.Testing
- {
-     using System;
-     using System.Collections.Generic;
-     using System.Linq;
-     using System.Linq.Expressions;
-     using System.Threading.Tasks;
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
 
-     static class TypeExtensions
-     {
-         public static IEnumerable<Func<object, object, IMessageHandlerContext, Task>> CreateInvokers(this Type targetType, Type messageType, Type interfaceGenericType)
-         {
-             var interfaceTypes = targetType.GetInterfaces()
-                 .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceGenericType)
-                 .Where(i => i.GenericTypeArguments.First().IsAssignableFrom(messageType));
+    static class TypeExtensions
+    {
+        public static IEnumerable<Func<object, object, IMessageHandlerContext, Task>> CreateInvokers(this Type targetType, Type messageType, Type interfaceGenericType)
+        {
+            var interfaceTypes = targetType.GetInterfaces()
+                .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceGenericType)
+                .Where(i => i.GenericTypeArguments.First().IsAssignableFrom(messageType));
 
-             foreach (var interfaceType in interfaceTypes)
-             {
+            foreach (var interfaceType in interfaceTypes)
+            {
                 var methodInfo = targetType.GetInterfaceMap(interfaceType).TargetMethods.FirstOrDefault();
                 if (methodInfo == null)
                 {
@@ -35,14 +35,14 @@
 
                 yield return Expression.Lambda<Func<object, object, IMessageHandlerContext, Task>>(body, target, messageParam, contextParam).Compile();
             }
-         }
+        }
 
-         public static async Task InvokeSerially(this IEnumerable<Func<object, object, IMessageHandlerContext, Task>> invokers, object instance, object message, IMessageHandlerContext context)
-         {
+        public static async Task InvokeSerially(this IEnumerable<Func<object, object, IMessageHandlerContext, Task>> invokers, object instance, object message, IMessageHandlerContext context)
+        {
             foreach (var invocation in invokers)
             {
                 await invocation(instance, message, context).ConfigureAwait(false);
             }
         }
-     }
- }
+    }
+}


### PR DESCRIPTION
Customers might have tons of those tests but if they are using xunit the GetAwaiter().GetResult() calls will deadlock in certain scenarios. This introduces async variants to allow customers to move to them. This makes it possible to get the tests unstuck from deadlocking and gives them the possibility to gradually then move when the time comes to the new testable overloads

See https://github.com/Particular/NServiceBus.Testing/issues/135#issuecomment-528799797

I'm aware that this contradicts the current async method naming guideline but I think for the testing lib for this specific case this is fine