### PR TITLE
Remove timeouts from sent messages

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -49,6 +49,7 @@ namespace NServiceBus.Testing
         public static System.Collections.Generic.IEnumerable<NServiceBus.Testing.PublishedMessage<TMessage>> Containing<TMessage>(this System.Collections.Generic.IEnumerable<NServiceBus.Testing.PublishedMessage<object>> publishedMessages) { }
         public static System.Collections.Generic.IEnumerable<NServiceBus.Testing.RepliedMessage<TMessage>> Containing<TMessage>(this System.Collections.Generic.IEnumerable<NServiceBus.Testing.RepliedMessage<object>> repliedMessages) { }
         public static System.Collections.Generic.IEnumerable<NServiceBus.Testing.SentMessage<TMessage>> Containing<TMessage>(this System.Collections.Generic.IEnumerable<NServiceBus.Testing.SentMessage<object>> sentMessages) { }
+        public static System.Collections.Generic.IEnumerable<NServiceBus.Testing.TimeoutMessage<TMessage>> Containing<TMessage>(this System.Collections.Generic.IEnumerable<NServiceBus.Testing.TimeoutMessage<object>> timeoutMessages) { }
         public static TMessage Message<TMessage>(this NServiceBus.Testing.PublishedMessage<object> sentMessage)
             where TMessage :  class { }
         public static TMessage Message<TMessage>(this NServiceBus.Testing.RepliedMessage<object> sentMessage)

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectDelayDeliveryWith.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectDelayDeliveryWith.cs
@@ -12,7 +12,7 @@
 
         public override void Validate(TestableMessageHandlerContext context)
         {
-            var sentMessages = context.SentMessages
+            var sentMessages = context.TimeoutMessages
                 .Containing<TMessage>()
                 .Where(s => s.Options.GetDeliveryDelay().HasValue)
                 .ToList();

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectDoNotDeliverBefore.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectDoNotDeliverBefore.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Testing
 
         public override void Validate(TestableMessageHandlerContext context)
         {
-            var sentMessages = context.SentMessages
+            var sentMessages = context.TimeoutMessages
                 .Containing<TMessage>()
                 .Where(s => s.Options.GetDeliveryDate().HasValue)
                 .ToList();

--- a/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDelayDeliveryWith.cs
+++ b/src/NServiceBus.Testing/ExpectedInvocations/ExpectNotDelayDeliveryWith.cs
@@ -12,7 +12,7 @@
 
         public override void Validate(TestableMessageHandlerContext context)
         {
-            var sentMessages = context.SentMessages
+            var sentMessages = context.TimeoutMessages
                 .Containing<TMessage>()
                 .Where(s => s.Options.GetDeliveryDelay().HasValue)
                 .ToList();

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/OutgoingMessageExtensions.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/OutgoingMessageExtensions.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Testing
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -38,6 +39,19 @@ namespace NServiceBus.Testing
             return sentMessages
                 .Where(x => x.Message is TMessage)
                 .Select(x => new SentMessage<TMessage>((TMessage)x.Message, x.Options));
+        }
+
+        /// <summary>
+        /// Returns all <see cref="TimeoutMessage{TMessage}"/> of the specified type contained in <paramref name="timeoutMessages"/>.
+        /// </summary>
+        public static IEnumerable<TimeoutMessage<TMessage>> Containing<TMessage>(
+            this IEnumerable<TimeoutMessage<object>> timeoutMessages)
+        {
+            return timeoutMessages
+                .Where(x => x.Message is TMessage)
+                .Select(x => x.At.HasValue ? new TimeoutMessage<TMessage>((TMessage)x.Message, x.Options, x.At.Value)
+                    : x.Within.HasValue ? new TimeoutMessage<TMessage>((TMessage)x.Message, x.Options, x.Within.Value)
+                        : throw new Exception("Timeout message does not have .At or .Within set."));
         }
 
         /// <summary>

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestablePipelineContext.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestablePipelineContext.cs
@@ -54,12 +54,19 @@
         {
             var headers = options.GetHeaders();
 
-            if (headers.ContainsKey(Headers.IsSagaTimeoutMessage))
+            var isTimeout = options.GetDeliveryDate().HasValue
+                            || options.GetDeliveryDelay().HasValue
+                            || headers.ContainsKey(Headers.IsSagaTimeoutMessage);
+
+            if (isTimeout)
             {
                 timeoutMessages.Enqueue(GetTimeoutMessage(message, options));
             }
+            else
+            {
+                sentMessages.Enqueue(new SentMessage<object>(message, options));
+            }
 
-            sentMessages.Enqueue(new SentMessage<object>(message, options));
             return Task.FromResult(0);
         }
 


### PR DESCRIPTION
Fixes #127 

A deferred message is conceptually different from a sent message, even if under the covers the message is still sent to the broker.

This is a breaking change that will not add timeout messages to the `SentMessages` collection, only the `TimeoutMessages`. All of the expectations around delayed delivery have been updated to check the `TimeoutMessages` collection only.