### PR TITLE
restore virtual methods on IMessageSession

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -257,10 +257,10 @@ namespace NServiceBus.Testing
         public virtual NServiceBus.Testing.Subscription[] Subscriptions { get; }
         public NServiceBus.Testing.TimeoutMessage<>[] TimeoutMessages { get; }
         public virtual NServiceBus.Testing.Unsubscription[] Unsubscription { get; }
-        public System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions publishOptions, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions publishOptions, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions sendOptions, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions sendOptions, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions publishOptions, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions publishOptions, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions sendOptions, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions sendOptions, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options, System.Threading.CancellationToken cancellationToken = default) { }
     }

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableMessageSession.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableMessageSession.cs
@@ -35,7 +35,6 @@
         /// </summary>
         public virtual PublishedMessage<object>[] PublishedMessages => publishedMessages.ToArray();
 
-
         /// <summary>
         /// A list of all event subscriptions made from this session.
         /// </summary>
@@ -77,7 +76,7 @@
         /// <param name="message">The message to send.</param>
         /// <param name="sendOptions">The options for the send.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        public Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
+        public virtual Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
         {
             var headers = sendOptions.GetHeaders();
 
@@ -97,7 +96,7 @@
         /// <param name="messageConstructor">An action which initializes properties of the message.</param>
         /// <param name="sendOptions">The options for the send.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions, CancellationToken cancellationToken = default) =>
+        public virtual Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions, CancellationToken cancellationToken = default) =>
             Send(messageCreator.CreateInstance(messageConstructor), sendOptions, cancellationToken);
 
         /// <summary>
@@ -106,7 +105,7 @@
         /// <param name="message">The message to publish.</param>
         /// <param name="publishOptions">The options for the publish.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        public Task Publish(object message, PublishOptions publishOptions, CancellationToken cancellationToken = default)
+        public virtual Task Publish(object message, PublishOptions publishOptions, CancellationToken cancellationToken = default)
         {
             publishedMessages.Enqueue(new PublishedMessage<object>(message, publishOptions));
             return Task.CompletedTask;
@@ -119,9 +118,8 @@
         /// <param name="messageConstructor">An action which initializes properties of the message.</param>
         /// <param name="publishOptions">Specific options for this event.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions, CancellationToken cancellationToken = default) =>
+        public virtual Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions, CancellationToken cancellationToken = default) =>
             Publish(messageCreator.CreateInstance(messageConstructor), publishOptions, cancellationToken);
-
 
         static TimeoutMessage<object> GetTimeoutMessage(object message, SendOptions options)
         {
@@ -139,11 +137,11 @@
         /// the <see cref="IMessageCreator" /> instance used to create proxy implementation for message interfaces.
         /// </summary>
         protected IMessageCreator messageCreator;
+
         readonly ConcurrentQueue<Subscription> subscriptions = new ConcurrentQueue<Subscription>();
         readonly ConcurrentQueue<Unsubscription> unsubscriptions = new ConcurrentQueue<Unsubscription>();
         readonly ConcurrentQueue<PublishedMessage<object>> publishedMessages = new ConcurrentQueue<PublishedMessage<object>>();
         readonly ConcurrentQueue<SentMessage<object>> sentMessages = new ConcurrentQueue<SentMessage<object>>();
         readonly ConcurrentQueue<TimeoutMessage<object>> timeoutMessages = new ConcurrentQueue<TimeoutMessage<object>>();
-
     }
 }


### PR DESCRIPTION
`TimeoutMessages` is still non-virtual, because it is non-virtual on `TestablePipelineContext`.