### PR TITLE
Obsolete missing API

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -151,6 +151,9 @@ namespace NServiceBus.Testing
     {
         protected NServiceBus.IMessageCreator messageCreator;
         public TestableMessageSession(NServiceBus.IMessageCreator messageCreator = null) { }
+        [System.Obsolete("The member currently throws a NotImplementedException. Will be removed in version" +
+            " 9.0.0.", true)]
+        public NServiceBus.Extensibility.ContextBag Extensions { get; set; }
         public virtual NServiceBus.Testing.PublishedMessage<>[] PublishedMessages { get; }
         public virtual NServiceBus.Testing.SentMessage<>[] SentMessages { get; }
         public virtual NServiceBus.Testing.Subscription[] Subscriptions { get; }

--- a/src/NServiceBus.Testing/obsoletes.cs
+++ b/src/NServiceBus.Testing/obsoletes.cs
@@ -57,4 +57,21 @@ namespace NServiceBus.Testing
     }
 }
 
+namespace NServiceBus.Testing
+{
+    using System;
+
+    public partial class TestableMessageSession
+    {
+        [ObsoleteEx(
+            RemoveInVersion = "9",
+            TreatAsErrorFromVersion = "8")]
+        public Extensibility.ContextBag Extensions
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+    }
+}
+
 #pragma warning restore 1591


### PR DESCRIPTION
This API was removed in v8 without being obsoleted: `TestableMessageSession.Extensions`