### PR TITLE
Spike: Resetting fakes

### DIFF
--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/NetFrameworkPolyfillExtensions.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/NetFrameworkPolyfillExtensions.cs
@@ -1,0 +1,16 @@
+﻿#if NETFRAMEWORK
+namespace NServiceBus.Testing
+{
+    using System.Collections.Concurrent;
+
+    static class NetFrameworkPolyfillExtensions
+    {
+        public static void Clear<T>(this ConcurrentQueue<T> queue)
+        {
+            while (queue.TryDequeue(out _))
+            {
+            }
+        }
+    }
+}
+#endif

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableIncomingContext.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableIncomingContext.cs
@@ -30,5 +30,12 @@
         {
             return ServiceCollection.BuildServiceProvider();
         }
+
+        /// <inheritdoc/>
+        public override void Reset()
+        {
+            base.Reset();
+            ServiceCollection = new ServiceCollection();
+        }
     }
 }

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableInvokeHandlerContext.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableInvokeHandlerContext.cs
@@ -63,5 +63,17 @@
         /// Metadata for the incoming message.
         /// </summary>
         public MessageMetadata MessageMetadata { get; set; } = new MessageMetadata(typeof(object));
+
+        /// <inheritdoc/>
+        public override void Reset()
+        {
+            base.Reset();
+            DoNotContinueDispatchingCurrentMessageToHandlersWasCalled = default;
+            SynchronizedStorageSession = default;
+            MessageHandler = new MessageHandler((instance, message, context) => Task.CompletedTask, typeof(object));
+            Headers.Clear();
+            MessageBeingHandled = new object();
+            MessageMetadata = new MessageMetadata(typeof(object));
+        }
     }
 }

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableMessageProcessingContext.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableMessageProcessingContext.cs
@@ -76,6 +76,16 @@ namespace NServiceBus.Testing
         /// </summary>
         public string ReplyToAddress { get; set; } = "reply address";
 
+        /// <inheritdoc/>
+        public override void Reset()
+        {
+            base.Reset();
+            forwardedMessages.Clear();
+            MessageHeaders.Clear();
+            MessageId = Guid.NewGuid().ToString();
+            ReplyToAddress = "reply address";
+        }
+
         IReadOnlyDictionary<string, string> IMessageProcessingContext.MessageHeaders => new ReadOnlyDictionary<string, string>(MessageHeaders);
         ConcurrentQueue<string> forwardedMessages = new ConcurrentQueue<string>();
 

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableMessageSession.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestableMessageSession.cs
@@ -134,6 +134,19 @@
         }
 
         /// <summary>
+        /// Resets the the stored collections of <see cref="SentMessages"/>, <see cref="PublishedMessages"/>, <see cref="TimeoutMessages"/>,
+        /// <see cref="Subscriptions"/>, and <see cref="Unsubscription"/> requests so that the testable session can be reused.
+        /// </summary>
+        public virtual void Reset()
+        {
+            sentMessages.Clear();
+            publishedMessages.Clear();
+            timeoutMessages.Clear();
+            subscriptions.Clear();
+            unsubscriptions.Clear();
+        }
+
+        /// <summary>
         /// the <see cref="IMessageCreator" /> instance used to create proxy implementation for message interfaces.
         /// </summary>
         protected IMessageCreator messageCreator;

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestablePipelineContext.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestablePipelineContext.cs
@@ -111,6 +111,19 @@
         }
 
         /// <summary>
+        /// Resets all the state held by this testable type so that it can be reused.
+        /// </summary>
+        public virtual void Reset()
+        {
+            sentMessages.Clear();
+            publishedMessages.Clear();
+            timeoutMessages.Clear();
+            Extensions = new ContextBag();
+            CancellationToken = default;
+
+        }
+
+        /// <summary>
         /// the <see cref="IMessageCreator" /> instance used to create proxy implementation for message interfaces.
         /// </summary>
         protected IMessageCreator messageCreator;


### PR DESCRIPTION
Spiking an implementation to address https://github.com/Particular/NServiceBus.Testing/issues/446

I'm not sure that I like this. Especially given the complex inheritance graph of `TestableMessageHandlerContext`, each level has to be responsible for resetting all its own state. Some of these default values, which are provided so that the end user doesn't have to worry about nulls, are pretty complex. What happens when a future enhancement adds some other bit of state, or changes a default, but forgets to make the corresponding update in the `Reset()` method? Now the Reset method has a bug where it doesn't reset the instance's state correctly. It would be _very_ hard to create a test that would ensure new state was reflected in the Reset method properly.

And, after all, there is already a foolproof, one-liner method to make sure that a context gets reset _perfectly_ every time:

```csharp
context = new TestableMessageHandlerContext()
```

Is another, error-prone method necessary?