### PR TITLE
Bring back the relevant testing extensions for TestableMessageSession

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -300,9 +300,12 @@ namespace NServiceBus.Testing
     }
     public static class TestingExtensions
     {
+        public static TMessage FindPublishedMessage<TMessage>(this NServiceBus.Testing.TestableMessageSession context) { }
         public static TMessage FindPublishedMessage<TMessage>(this NServiceBus.Testing.TestablePipelineContext context) { }
         public static TMessage FindReplyMessage<TMessage>(this NServiceBus.Testing.TestableMessageProcessingContext context) { }
+        public static TMessage FindSentMessage<TMessage>(this NServiceBus.Testing.TestableMessageSession context) { }
         public static TMessage FindSentMessage<TMessage>(this NServiceBus.Testing.TestablePipelineContext context) { }
+        public static TMessage FindTimeoutMessage<TMessage>(this NServiceBus.Testing.TestableMessageSession context) { }
         public static TMessage FindTimeoutMessage<TMessage>(this NServiceBus.Testing.TestablePipelineContext context) { }
     }
     public class TestingLoggerFactory : NServiceBus.Logging.LoggingFactoryDefinition

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingExtensions.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingExtensions.cs
@@ -15,11 +15,11 @@
             (TMessage)context.PublishedMessages.FirstOrDefault(msg => msg.Message is TMessage)?.Message;
 
         /// <summary>
-        /// Returns the first sent message of a given type,
-        /// or a default value if there is no sent message of the given type.
+        /// Returns the first published message of a given type,
+        /// or a default value if there is no published message of the given type.
         /// </summary>
-        public static TMessage FindSentMessage<TMessage>(this TestablePipelineContext context) =>
-            (TMessage)context.SentMessages.FirstOrDefault(msg => msg.Message is TMessage)?.Message;
+        public static TMessage FindPublishedMessage<TMessage>(this TestableMessageSession context) =>
+            (TMessage)context.PublishedMessages.FirstOrDefault(msg => msg.Message is TMessage)?.Message;
 
         /// <summary>
         /// Returns the first timeout message of a given type,
@@ -27,6 +27,27 @@
         /// </summary>
         public static TMessage FindTimeoutMessage<TMessage>(this TestablePipelineContext context) =>
             (TMessage)context.TimeoutMessages.FirstOrDefault(msg => msg.Message is TMessage)?.Message;
+
+        /// <summary>
+        /// Returns the first timeout message of a given type,
+        /// or a default value if there is no timeout message of the given type.
+        /// </summary>
+        public static TMessage FindTimeoutMessage<TMessage>(this TestableMessageSession context) =>
+            (TMessage)context.TimeoutMessages.FirstOrDefault(msg => msg.Message is TMessage)?.Message;
+
+        /// <summary>
+        /// Returns the first sent message of a given type,
+        /// or a default value if there is no sent message of the given type.
+        /// </summary>
+        public static TMessage FindSentMessage<TMessage>(this TestableMessageSession context) =>
+            (TMessage)context.SentMessages.FirstOrDefault(msg => msg.Message is TMessage)?.Message;
+
+        /// <summary>
+        /// Returns the first sent message of a given type,
+        /// or a default value if there is no sent message of the given type.
+        /// </summary>
+        public static TMessage FindSentMessage<TMessage>(this TestablePipelineContext context) =>
+            (TMessage)context.SentMessages.FirstOrDefault(msg => msg.Message is TMessage)?.Message;
 
         /// <summary>
         /// Returns the first replied message of a given type,


### PR DESCRIPTION
Fixes #533 

Brings back extension methods for `TestableMessageSession` that were accidentally removed as part of https://github.com/Particular/NServiceBus.Testing/pull/274