### PR TITLE
Add support for mocking saga finders

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -220,7 +220,7 @@ namespace NServiceBus.Testing
         where TSaga : NServiceBus.Saga<TSagaData>
         where TSagaData :  class, NServiceBus.IContainSagaData, new ()
     {
-        public TestableSaga(System.Func<TSaga> sagaFactory = null, System.DateTime? initialCurrentTime = default) { }
+        public TestableSaga(System.Func<TSaga> sagaFactory = null, System.DateTime? initialCurrentTime = default, System.Collections.Generic.List<System.Type> sagaFinders = null) { }
         public System.DateTime CurrentTime { get; }
         public bool HasQueuedMessages { get; }
         public int QueueLength { get; }

--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -228,7 +228,7 @@ namespace NServiceBus.Testing
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> Handle<TMessage>(TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleQueuedMessage(NServiceBus.Testing.TestableMessageHandlerContext context = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleReply<TMessage>(System.Guid sagaId, TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
-        public void MockSagaFinder<TMessage>(System.Func<TMessage, System.Guid> mockFinder) { }
+        public void MockSagaFinder<TMessage>(System.Func<TMessage, System.Guid?> mockFinder) { }
         public void MockSagaFinder<TMessage>([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "propertyName",
                 "propertyValue"})] System.Func<TMessage, System.ValueTuple<string, object>> mockFinder) { }

--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -228,6 +228,7 @@ namespace NServiceBus.Testing
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> Handle<TMessage>(TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleQueuedMessage(NServiceBus.Testing.TestableMessageHandlerContext context = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleReply<TMessage>(System.Guid sagaId, TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
+        public void MockSagaFinder<TMessage>(System.Func<TMessage, System.Guid> mockFinder) { }
         public void MockSagaFinder<TMessage>([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "propertyName",
                 "propertyValue"})] System.Func<TMessage, System.ValueTuple<string, object>> mockFinder) { }

--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -220,7 +220,7 @@ namespace NServiceBus.Testing
         where TSaga : NServiceBus.Saga<TSagaData>
         where TSagaData :  class, NServiceBus.IContainSagaData, new ()
     {
-        public TestableSaga(System.Func<TSaga> sagaFactory = null, System.DateTime? initialCurrentTime = default, System.Collections.Generic.List<System.Type> sagaFinders = null) { }
+        public TestableSaga(System.Func<TSaga> sagaFactory = null, System.DateTime? initialCurrentTime = default) { }
         public System.DateTime CurrentTime { get; }
         public bool HasQueuedMessages { get; }
         public int QueueLength { get; }
@@ -228,6 +228,9 @@ namespace NServiceBus.Testing
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> Handle<TMessage>(TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleQueuedMessage(NServiceBus.Testing.TestableMessageHandlerContext context = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleReply<TMessage>(System.Guid sagaId, TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
+        public void MockSagaFinder<TMessage>([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "propertyName",
+                "propertyValue"})] System.Func<TMessage, System.ValueTuple<string, object>> mockFinder) { }
         public NServiceBus.Testing.QueuedSagaMessage QueuePeek() { }
         public void SimulateReply<TSagaMessage, TReplyMessage>(System.Func<TSagaMessage, TReplyMessage> simulateReply) { }
         [System.Diagnostics.DebuggerDisplay("HandleResult: {HandledMessage.Message}")]

--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -228,8 +228,8 @@ namespace NServiceBus.Testing
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> Handle<TMessage>(TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleQueuedMessage(NServiceBus.Testing.TestableMessageHandlerContext context = null) { }
         public System.Threading.Tasks.Task<NServiceBus.Testing.TestableSaga<TSaga, TSagaData>.HandleResult> HandleReply<TMessage>(System.Guid sagaId, TMessage message, NServiceBus.Testing.TestableMessageHandlerContext context = null, System.Collections.Generic.IReadOnlyDictionary<string, string> messageHeaders = null) { }
-        public void MockSagaFinder<TMessage>(System.Func<TMessage, System.Guid?> mockFinder) { }
-        public void MockSagaFinder<TMessage>([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        public void MockSagaFinder<TMessage>(System.Func<TMessage, object> correlationIdGetter, System.Func<TMessage, System.Guid?> mockFinder) { }
+        public void MockSagaFinder<TMessage>(System.Func<TMessage, object> correlationIdGetter, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "propertyName",
                 "propertyValue"})] System.Func<TMessage, System.ValueTuple<string, object>> mockFinder) { }
         public NServiceBus.Testing.QueuedSagaMessage QueuePeek() { }

--- a/src/NServiceBus.Testing.Tests/Sagas/SagaWithSagaFinder.cs
+++ b/src/NServiceBus.Testing.Tests/Sagas/SagaWithSagaFinder.cs
@@ -102,13 +102,12 @@
 
         public class ShippingDelay { }
 
-        public class SagaFinder : ISagaFinder<ShippingPolicyData, OrderBilled>
+        public class FakeSagaFinder(ISagaPersister sagaPersister) : ISagaFinder<ShippingPolicyData, OrderBilled>
         {
             public Task<ShippingPolicyData> FindBy(OrderBilled message, ISynchronizedStorageSession storageSession,
-                IReadOnlyContextBag context, CancellationToken cancellationToken = default)
-            {
-                return Task.FromResult(new ShippingPolicyData());
-            }
+                IReadOnlyContextBag context, CancellationToken cancellationToken = default) =>
+                sagaPersister.Get<ShippingPolicyData>("OrderId", message.OrderId, storageSession, (ContextBag)context,
+                    cancellationToken);
         }
     }
 }

--- a/src/NServiceBus.Testing.Tests/Sagas/SagaWithSagaFinder.cs
+++ b/src/NServiceBus.Testing.Tests/Sagas/SagaWithSagaFinder.cs
@@ -1,0 +1,114 @@
+﻿namespace NServiceBus.Testing.Tests.Sagas
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NServiceBus.Sagas;
+    using NUnit.Framework;
+    using Persistence;
+
+    [TestFixture]
+    public class SagaWithSagaFinder
+    {
+        [Test]
+        public async Task TestSagaWithSagaFinder()
+        {
+            var testableSaga = new TestableSaga<ShippingPolicy, ShippingPolicyData>(sagaFinders: [typeof(SagaFinder)]);
+
+            var placeResult = await testableSaga.Handle(new OrderPlaced { OrderId = "abc" });
+            var billResult = await testableSaga.Handle(new OrderBilled { OrderId = "abc" });
+
+            Assert.That(placeResult.Completed, Is.False);
+            Assert.That(billResult.Completed, Is.False);
+
+            // Snapshots of data should still be assertable even after multiple operations have occurred.
+            Assert.That(placeResult.SagaDataSnapshot.OrderId, Is.EqualTo("abc"));
+            Assert.That(placeResult.SagaDataSnapshot.Placed, Is.True);
+            Assert.That(placeResult.SagaDataSnapshot.Billed, Is.False);
+
+            var noResults = await testableSaga.AdvanceTime(TimeSpan.FromMinutes(10));
+            Assert.That(noResults.Length, Is.EqualTo(0));
+
+            var timeoutResults = await testableSaga.AdvanceTime(TimeSpan.FromHours(1));
+
+            Assert.That(timeoutResults.Length, Is.EqualTo(1));
+
+            var shipped = timeoutResults.First().FindPublishedMessage<OrderShipped>();
+            Assert.That(shipped.OrderId == "abc");
+        }
+
+        public class ShippingPolicy : Saga<ShippingPolicyData>,
+            IAmStartedByMessages<OrderPlaced>,
+#pragma warning disable NSB0006
+            //using a saga finder — no explicit mapping for OrderBilled
+            IAmStartedByMessages<OrderBilled>,
+#pragma warning restore NSB0006
+            IHandleTimeouts<ShippingDelay>
+        {
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ShippingPolicyData> mapper)
+            {
+                mapper.MapSaga(saga => saga.OrderId)
+                    .ToMessage<OrderPlaced>(msg => msg.OrderId);
+            }
+
+            public Task Handle(OrderPlaced message, IMessageHandlerContext context)
+            {
+                Data.Placed = true;
+                return TimeToShip(context);
+            }
+            public Task Handle(OrderBilled message, IMessageHandlerContext context)
+            {
+                Data.Billed = true;
+                return TimeToShip(context);
+            }
+            public async Task TimeToShip(IMessageHandlerContext context)
+            {
+                if (Data.Placed && Data.Billed)
+                {
+                    await RequestTimeout<ShippingDelay>(context, TimeSpan.FromMinutes(15));
+                }
+            }
+
+            public async Task Timeout(ShippingDelay state, IMessageHandlerContext context)
+            {
+                await context.Publish(new OrderShipped { OrderId = Data.OrderId });
+                MarkAsComplete();
+            }
+        }
+
+        public class ShippingPolicyData : ContainSagaData
+        {
+            public string OrderId { get; set; }
+            public bool Placed { get; set; }
+            public bool Billed { get; set; }
+        }
+
+        public class OrderPlaced : IEvent
+        {
+            public string OrderId { get; set; }
+        }
+
+        public class OrderBilled : IEvent
+        {
+            public string OrderId { get; set; }
+        }
+
+        public class OrderShipped : IEvent
+        {
+            public string OrderId { get; set; }
+        }
+
+        public class ShippingDelay { }
+
+        public class SagaFinder : ISagaFinder<ShippingPolicyData, OrderBilled>
+        {
+            public Task<ShippingPolicyData> FindBy(OrderBilled message, ISynchronizedStorageSession storageSession,
+                IReadOnlyContextBag context, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(new ShippingPolicyData());
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Testing.Tests/Sagas/SagaWithSagaFinder.cs
+++ b/src/NServiceBus.Testing.Tests/Sagas/SagaWithSagaFinder.cs
@@ -15,7 +15,7 @@
         [Test]
         public async Task TestSagaWithSagaFinder()
         {
-            var testableSaga = new TestableSaga<ShippingPolicy, ShippingPolicyData>(sagaFinders: [typeof(SagaFinder)]);
+            var testableSaga = new TestableSaga<ShippingPolicy, ShippingPolicyData>(sagaFinders: [typeof(FakeSagaFinder)]);
 
             var placeResult = await testableSaga.Handle(new OrderPlaced { OrderId = "abc" });
             var billResult = await testableSaga.Handle(new OrderBilled { OrderId = "abc" });

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
@@ -53,10 +53,7 @@
         /// </summary>
         protected override ILoggerFactory GetLoggingFactory()
         {
-            if (testingLoggerFactory == null)
-            {
-                testingLoggerFactory = new DefaultTestingLoggerFactory();
-            }
+            testingLoggerFactory ??= new DefaultTestingLoggerFactory();
 
             return testingLoggerFactory;
         }

--- a/src/NServiceBus.Testing/Sagas/PropertyNameAndValueMockSagaFinder.cs
+++ b/src/NServiceBus.Testing/Sagas/PropertyNameAndValueMockSagaFinder.cs
@@ -7,10 +7,12 @@ using Extensibility;
 using Persistence;
 using Sagas;
 
-class PropertyNameAndValueMockSagaFinder<TSagaData, TMessage>(ISagaPersister sagaPersister, Func<TMessage, (string propertyName, object propertyValue)> mockFinder)
-    : ISagaFinder<TSagaData, TMessage>
+class PropertyNameAndValueMockSagaFinder<TSagaData, TMessage>(ISagaPersister sagaPersister, Func<TMessage, object> correlationIdGetter, Func<TMessage, (string propertyName, object propertyValue)> mockFinder)
+    : ISagaFinder<TSagaData, TMessage>, IExposeCorrelationId<TMessage>
     where TSagaData : class, IContainSagaData
 {
+    public object GetCorrelationId(TMessage message) => correlationIdGetter(message);
+
     public Task<TSagaData> FindBy(TMessage message, ISynchronizedStorageSession storageSession,
         IReadOnlyContextBag context, CancellationToken cancellationToken = default)
     {

--- a/src/NServiceBus.Testing/Sagas/PropertyNameAndValueMockSagaFinder.cs
+++ b/src/NServiceBus.Testing/Sagas/PropertyNameAndValueMockSagaFinder.cs
@@ -19,3 +19,16 @@ class PropertyNameAndValueMockSagaFinder<TSagaData, TMessage>(ISagaPersister sag
             cancellationToken);
     }
 }
+
+class SagaIdMockSagaFinder<TSagaData, TMessage>(ISagaPersister sagaPersister, Func<TMessage, Guid> mockFinder)
+    : ISagaFinder<TSagaData, TMessage>
+    where TSagaData : class, IContainSagaData
+{
+    public Task<TSagaData> FindBy(TMessage message, ISynchronizedStorageSession storageSession,
+        IReadOnlyContextBag context, CancellationToken cancellationToken = default)
+    {
+        var sagaId = mockFinder(message);
+        return sagaPersister.Get<TSagaData>(sagaId, storageSession, (ContextBag)context,
+            cancellationToken);
+    }
+}

--- a/src/NServiceBus.Testing/Sagas/PropertyNameAndValueMockSagaFinder.cs
+++ b/src/NServiceBus.Testing/Sagas/PropertyNameAndValueMockSagaFinder.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.Testing;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Extensibility;
+using Persistence;
+using Sagas;
+
+class PropertyNameAndValueMockSagaFinder<TSagaData, TMessage>(ISagaPersister sagaPersister, Func<TMessage, (string propertyName, object propertyValue)> mockFinder)
+    : ISagaFinder<TSagaData, TMessage>
+    where TSagaData : class, IContainSagaData
+{
+    public Task<TSagaData> FindBy(TMessage message, ISynchronizedStorageSession storageSession,
+        IReadOnlyContextBag context, CancellationToken cancellationToken = default)
+    {
+        var (propertyName, propertyValue) = mockFinder(message);
+        return sagaPersister.Get<TSagaData>(propertyName, propertyValue, storageSession, (ContextBag)context,
+            cancellationToken);
+    }
+}

--- a/src/NServiceBus.Testing/Sagas/SagaIdMockSagaFinder.cs
+++ b/src/NServiceBus.Testing/Sagas/SagaIdMockSagaFinder.cs
@@ -7,10 +7,12 @@ using Extensibility;
 using Persistence;
 using Sagas;
 
-class SagaIdMockSagaFinder<TSagaData, TMessage>(ISagaPersister sagaPersister, Func<TMessage, Guid?> mockFinder)
-    : ISagaFinder<TSagaData, TMessage>
+class SagaIdMockSagaFinder<TSagaData, TMessage>(ISagaPersister sagaPersister, Func<TMessage, object> correlationIdGetter, Func<TMessage, Guid?> mockFinder)
+    : ISagaFinder<TSagaData, TMessage>, IExposeCorrelationId<TMessage>
     where TSagaData : class, IContainSagaData
 {
+    public object GetCorrelationId(TMessage message) => correlationIdGetter(message);
+
     public Task<TSagaData> FindBy(TMessage message, ISynchronizedStorageSession storageSession,
         IReadOnlyContextBag context, CancellationToken cancellationToken = default)
     {
@@ -22,4 +24,9 @@ class SagaIdMockSagaFinder<TSagaData, TMessage>(ISagaPersister sagaPersister, Fu
 
         return sagaData;
     }
+}
+
+interface IExposeCorrelationId<TMessage>
+{
+    object GetCorrelationId(TMessage message);
 }

--- a/src/NServiceBus.Testing/Sagas/SagaMapper.cs
+++ b/src/NServiceBus.Testing/Sagas/SagaMapper.cs
@@ -38,11 +38,8 @@
                 throw new Exception($"Could not test saga {sagaType.Name} because a property on {sagaType.Name} matching the correlation property '{correlationProperty.Name}' could not be located.");
             }
 
-            var configureHowToFindMethod = sagaType.GetMethod("ConfigureHowToFindSaga", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(IConfigureHowToFindSagaWithMessage) }, null);
-            if (configureHowToFindMethod == null)
-            {
-                throw new Exception($"Could not test saga {sagaType.Name} because the ConfigureHowToFindSaga method could not be located.");
-            }
+            var configureHowToFindMethod = sagaType.GetMethod("ConfigureHowToFindSaga", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(IConfigureHowToFindSagaWithMessage) }, null)
+                                           ?? throw new Exception($"Could not test saga {sagaType.Name} because the ConfigureHowToFindSaga method could not be located.");
 
             var mappingReader = new MappingReader();
             configureHowToFindMethod.Invoke(dummySagaForReflection, new object[] { mappingReader });

--- a/src/NServiceBus.Testing/Sagas/TestableSaga.cs
+++ b/src/NServiceBus.Testing/Sagas/TestableSaga.cs
@@ -554,5 +554,11 @@
             var finder = new PropertyNameAndValueMockSagaFinder<TSagaData, TMessage>(persister, mockFinder);
             mockSagaFinders.Add(finder.GetType(), finder);
         }
+
+        public void MockSagaFinder<TMessage>(Func<TMessage, Guid> mockFinder)
+        {
+            var finder = new SagaIdMockSagaFinder<TSagaData, TMessage>(persister, mockFinder);
+            mockSagaFinders.Add(finder.GetType(), finder);
+        }
     }
 }

--- a/src/NServiceBus.Testing/Sagas/TestableSaga.cs
+++ b/src/NServiceBus.Testing/Sagas/TestableSaga.cs
@@ -553,6 +553,7 @@
         /// <summary>
         /// Add a mock saga finder for the given message type.
         /// </summary>
+        /// <param name="correlationIdGetter">A delegate that returns to saga correlation property value</param>
         /// <param name="mockFinder">A delegate that returns the saga property name and value to match</param>
         /// <typeparam name="TMessage">The message type to use with the saga finder</typeparam>
         /// <returns>The property name and value to use to find the saga instance</returns>
@@ -565,6 +566,7 @@
         /// <summary>
         /// Add a mock saga finder for the given message type.
         /// </summary>
+        /// <param name="correlationIdGetter">A delegate that returns to saga correlation property value</param>
         /// <param name="mockFinder">A delegate that returns the saga property name and value to match</param>
         /// <typeparam name="TMessage">The message type to use with the saga finder</typeparam>
         /// <returns>The saga identifier or null to signal that a new saga instance should be created</returns>

--- a/src/NServiceBus.Testing/Sagas/TestableSaga.cs
+++ b/src/NServiceBus.Testing/Sagas/TestableSaga.cs
@@ -102,10 +102,7 @@
         /// </returns>
         public Task<HandleResult> Handle<TMessage>(TMessage message, TestableMessageHandlerContext context = null, IReadOnlyDictionary<string, string> messageHeaders = null)
         {
-            if (context == null)
-            {
-                context = new TestableMessageHandlerContext();
-            }
+            context ??= new TestableMessageHandlerContext();
             var queueMessage = new QueuedSagaMessage(typeof(TMessage), message, messageHeaders);
             return InnerHandle(queueMessage, "Handle", context);
         }
@@ -169,10 +166,7 @@
                 throw new Exception("There are no queued messages.");
             }
 
-            if (context == null)
-            {
-                context = new TestableMessageHandlerContext();
-            }
+            context ??= new TestableMessageHandlerContext();
 
             var queuedMessage = queue.Dequeue();
             return InnerHandle(queuedMessage, "Handle", context);

--- a/src/NServiceBus.Testing/Sagas/TestableSaga.cs
+++ b/src/NServiceBus.Testing/Sagas/TestableSaga.cs
@@ -549,13 +549,20 @@
         /// </summary>
         /// <param name="mockFinder">A delegate that returns the saga property name and value to match</param>
         /// <typeparam name="TMessage">The message type to use with the saga finder</typeparam>
+        /// <returns>The property name and value to use to find the saga instance</returns>
         public void MockSagaFinder<TMessage>(Func<TMessage, (string propertyName, object propertyValue)> mockFinder)
         {
             var finder = new PropertyNameAndValueMockSagaFinder<TSagaData, TMessage>(persister, mockFinder);
             mockSagaFinders.Add(finder.GetType(), finder);
         }
 
-        public void MockSagaFinder<TMessage>(Func<TMessage, Guid> mockFinder)
+        /// <summary>
+        /// Add a mock saga finder for the given message type.
+        /// </summary>
+        /// <param name="mockFinder">A delegate that returns the saga property name and value to match</param>
+        /// <typeparam name="TMessage">The message type to use with the saga finder</typeparam>
+        /// <returns>The saga identifier or null to signal that a new saga instance should be created</returns>
+        public void MockSagaFinder<TMessage>(Func<TMessage, Guid?> mockFinder)
         {
             var finder = new SagaIdMockSagaFinder<TSagaData, TMessage>(persister, mockFinder);
             mockSagaFinders.Add(finder.GetType(), finder);

--- a/src/NServiceBus.Testing/Sagas/TestableSaga.cs
+++ b/src/NServiceBus.Testing/Sagas/TestableSaga.cs
@@ -21,7 +21,7 @@
         where TSaga : Saga<TSagaData>
         where TSagaData : class, IContainSagaData, new()
     {
-        Dictionary<Type, IFinder> mockSagaFinders = [];
+        readonly Dictionary<Type, IFinder> mockSagaFinders = [];
         readonly Func<TSaga> sagaFactory;
         readonly Queue<QueuedSagaMessage> queue;
         readonly ISagaPersister persister;
@@ -41,7 +41,6 @@
         /// Sets the initial value of <see cref="CurrentTime"/>.
         /// If not supplied, the default is <see cref="DateTime.UtcNow"/>.
         /// </param>
-        /// <param name="sagaFinders">The list of saga finders that can find the tested saga.</param>
         public TestableSaga(Func<TSaga> sagaFactory = null, DateTime? initialCurrentTime = null)
         {
             this.sagaFactory = sagaFactory ?? Activator.CreateInstance<TSaga>;


### PR DESCRIPTION
When a saga uses saga finders, not all messages are mapped. The testable saga instance fails to create the saga because the underlying saga mapper cannot find all the required mappings.

This PR adds the option to add mock saga finders to the testable saga instance, as follows:

```csharp
var testableSaga = new TestableSaga<ShippingPolicy, ShippingPolicyData>();
testableSaga.MockSagaFinder<OrderBilled>(
    correlationIdGetter: message => message.OrderId,
    mockFinder: message => ("OrderId", message.OrderId));
```

The `correlationIdGetter` is useful when the message at play can also start a new saga (`IAmStartedBy<>`); the underlying infrastructure needs the correlation property value.

The `mockFinder` is responsible for returning the property name and value to use when looking up the saga instance. If a property name and value are not available, e.g. when using complex finding logic, the saga identifier can be used, as follows:

```csharp
var testableSaga = new TestableSaga<ShippingPolicy, ShippingPolicyData>();

Guid sagaId = default;
testableSaga.MockSagaFinder<OrderBilled>(
    correlationIdGetter: message => message.OrderId,
    mockFinder: message => sagaId);

var placeResult = await testableSaga.Handle(new OrderPlaced { OrderId = "abc" });
sagaId = placeResult.SagaId;
```

In both cases, if the mock finder returns `null`, a new saga instance will be created.