### PR TITLE
Map custom saga finders and not found handlers in the saga scenario testing infrastructure

### DIFF
--- a/src/NServiceBus.Testing.Tests/Sagas/CustomFinder.cs
+++ b/src/NServiceBus.Testing.Tests/Sagas/CustomFinder.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Testing.Tests.Sagas;
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Extensibility;

--- a/src/NServiceBus.Testing.Tests/Sagas/NotFoundHandler.cs
+++ b/src/NServiceBus.Testing.Tests/Sagas/NotFoundHandler.cs
@@ -1,0 +1,77 @@
+﻿namespace NServiceBus.Testing.Tests.Sagas;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+[TestFixture]
+public class NotFoundHandler
+{
+    [Test]
+    public async Task TestSagaWithNotFoundHandler()
+    {
+        var testableSaga = new TestableSaga<SagaWithCustomFinder, CustomFinderSagaData>();
+
+        var placeResult = await testableSaga.Handle(new OrderPlaced { OrderId = "abc" });
+
+        var exception = Assert.ThrowsAsync<Exception>(async () => await testableSaga.Handle(new OrderBilled { OrderId = "abc" }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(placeResult.Completed, Is.True);
+            Assert.That(placeResult.SagaDataSnapshot.Placed, Is.True);
+            Assert.That(placeResult.SagaDataSnapshot.Billed, Is.False);
+            Assert.That(exception?.Message, Contains.Substring("Saga not found").And.Contains("not allowed to start the saga"));
+        });
+    }
+
+    public class SagaWithCustomFinder : Saga<CustomFinderSagaData>,
+        IAmStartedByMessages<OrderPlaced>,
+        IHandleMessages<OrderBilled>
+    {
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CustomFinderSagaData> mapper)
+        {
+            mapper.MapSaga(saga => saga.OrderId)
+                .ToMessage<OrderPlaced>(msg => msg.OrderId)
+                .ToMessage<OrderBilled>(msg => msg.OrderId);
+
+            mapper.ConfigureNotFoundHandler<NotFoundHandlerClass>();
+        }
+
+        public Task Handle(OrderPlaced message, IMessageHandlerContext context)
+        {
+            Data.Placed = true;
+            MarkAsComplete();
+            return Task.CompletedTask;
+        }
+
+        public async Task Handle(OrderBilled message, IMessageHandlerContext context)
+        {
+            Data.Placed = true;
+            await context.Send(new OrderBilled { OrderId = message.OrderId });
+            MarkAsComplete(); // Saga won't be around to get message
+        }
+    }
+
+    public class NotFoundHandlerClass : ISagaNotFoundHandler
+    {
+        public Task Handle(object message, IMessageProcessingContext context) => Task.CompletedTask;
+    }
+
+    public class CustomFinderSagaData : ContainSagaData
+    {
+        public string OrderId { get; set; }
+        public bool Placed { get; set; }
+        public bool Billed { get; set; }
+    }
+
+    public class OrderPlaced : IEvent
+    {
+        public string OrderId { get; set; }
+    }
+
+    public class OrderBilled : IEvent
+    {
+        public string OrderId { get; set; }
+    }
+}

--- a/src/NServiceBus.Testing/Sagas/SagaMapper.cs
+++ b/src/NServiceBus.Testing/Sagas/SagaMapper.cs
@@ -87,7 +87,7 @@ class SagaMapper
         return invokeTask;
     }
 
-    class MappingReader : IConfigureHowToFindSagaWithMessage, IConfigureHowToFindSagaWithMessageHeaders, IConfigureHowToFindSagaWithFinder
+    class MappingReader : IConfigureHowToFindSagaWithMessage, IConfigureHowToFindSagaWithMessageHeaders, IConfigureHowToFindSagaWithFinder, IConfigureSagaNotFoundHandler
     {
         readonly Dictionary<Type, SagaMapping> mappings = [];
 
@@ -105,6 +105,11 @@ class SagaMapper
         }
 
         void IConfigureHowToFindSagaWithFinder.ConfigureMapping<TSagaEntity, TMessage, TFinder>() => mappings.Add(typeof(TMessage), new SagaMapping(null, true));
+
+        public void ConfigureSagaNotFoundHandler<TNotFoundHandler>() where TNotFoundHandler : ISagaNotFoundHandler
+        {
+            // Do nothing, framework doesn't explicitly test not found handlers
+        }
 
         public IReadOnlyDictionary<Type, SagaMapping> GetMappings() => mappings.AsReadOnly();
     }


### PR DESCRIPTION
This was a regression since v9; https://github.com/Particular/NServiceBus.Testing/pull/812 adds tests to confirm the previous behavior.

- Fixes https://github.com/Particular/NServiceBus.Testing/issues/814