### PR TITLE
Better obsolete message for TestingLoggerFactory

### DIFF
--- a/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -275,9 +275,9 @@ namespace NServiceBus.Testing
         public static TMessage FindTimeoutMessage<TMessage>(this NServiceBus.Testing.TestableMessageSession context) { }
         public static TMessage FindTimeoutMessage<TMessage>(this NServiceBus.Testing.TestablePipelineContext context) { }
     }
-    [System.Obsolete("Implement a custom logger using Microsoft.Extensions.Logging.ILoggerProvider inst" +
-        "ead. Will be treated as an error from version 11.0.0. Will be removed in version" +
-        " 12.0.0.", false)]
+    [System.Obsolete("Convert to logging using Microsoft.Extensions.Logging.ILogger and then use a test" +
+        "able implementation of ILogger for log-based tests. Will be treated as an error " +
+        "from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public class TestingLoggerFactory : NServiceBus.Logging.LoggingFactoryDefinition
     {
         public TestingLoggerFactory() { }

--- a/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing/NSB.Testing.Fakes/TestingLoggerFactory.cs
@@ -10,10 +10,10 @@ using Particular.Obsoletes;
 /// Logger factory which allows to log to a text writer.
 /// </summary>
 [ObsoleteMetadata(
-    Message = "Implement a custom logger using Microsoft.Extensions.Logging.ILoggerProvider instead",
+    Message = "Convert to logging using Microsoft.Extensions.Logging.ILogger and then use a testable implementation of ILogger for log-based tests",
     TreatAsErrorFromVersion = "11",
     RemoveInVersion = "12")]
-[Obsolete("Implement a custom logger using Microsoft.Extensions.Logging.ILoggerProvider instead. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
+[Obsolete("Convert to logging using Microsoft.Extensions.Logging.ILogger and then use a testable implementation of ILogger for log-based tests. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
 public class TestingLoggerFactory : LoggingFactoryDefinition
 {
     /// <summary>


### PR DESCRIPTION
Obsolete message more accurately points to the correct path of converting to using Microsoft.Extensions.Logging loggers.